### PR TITLE
Вместо слеша при формировании пути надо использовать GetPathSeparator…

### DIFF
--- a/example/VanessaEditorSample/Forms/Form/Ext/Form/Module.bsl
+++ b/example/VanessaEditorSample/Forms/Form/Ext/Form/Module.bsl
@@ -631,7 +631,7 @@ Procedure VanessaEditorLoad()
 	ZipFileReader = New ZipFileReader(BinaryData.OpenStreamForRead());
 	For each ZipFileEntry In ZipFileReader.Items Do
 		ZipFileReader.Extract(ZipFileEntry, TempFileName, ZIPRestoreFilePathsMode.Restore);
-		BinaryData = New BinaryData(TempFileName + "/" + ZipFileEntry.FullName);
+		BinaryData = New BinaryData(TempFileName + GetPathSeparator() + ZipFileEntry.FullName);
 		VanessaEditorURL = GetInfoBaseURL() + "/" + PutToTempStorage(BinaryData, UUID)
 			+ "&localeCode=" + Left(CurrentSystemLanguage(), 2);
 	EndDo;
@@ -796,7 +796,7 @@ Function VanessaStepList(language)
 	For each ZipFileEntry In ZipFileReader.Items Do
 		If ZipFileEntry.BaseName = language Then
 			ZipFileReader.Extract(ZipFileEntry, TempFileName, ZIPRestoreFilePathsMode.Restore);
-			BinaryData = New BinaryData(TempFileName + "/" + ZipFileEntry.FullName);
+			BinaryData = New BinaryData(TempFileName + GetPathSeparator() + ZipFileEntry.FullName);
 			TextReader = New TextReader(BinaryData.OpenStreamForRead(), TextEncoding.UTF8);
 			Result = TextReader.Read();
 		EndIf;
@@ -922,9 +922,9 @@ EndProcedure
 
 &AtClient
 Procedure ShowMinimapOnChange(Item)
-	
+
 	VanessaEditor.showMinimap(ShowMinimap);
-	
+
 EndProcedure
 
 #EndRegion

--- a/example/VanessaEditorSample/Forms/Form/Ext/Form/Module.bsl
+++ b/example/VanessaEditorSample/Forms/Form/Ext/Form/Module.bsl
@@ -9,7 +9,7 @@ Var KeyCodeMap;
 &AtServer
 Procedure OnCreateAtServer(Cancel, StandardProcessing)
 
-	VanessaEditorLoad();
+	VanessaEditorLoad(FormAttributeToValue("Object").GetTemplate("VanessaEditor"));
 	ErrorCode = New UUID;
 	ErrorText = "Runtime error info";
 	MessageText = "Hello, world!";
@@ -621,14 +621,13 @@ EndProcedure
 #Region Public
 
 &AtServer
-Procedure VanessaEditorLoad()
+Procedure VanessaEditorLoad(TemplateBinaryData)
 
 	TempFileName = GetTempFileName();
 	DeleteFiles(TempFileName);
 	CreateDirectory(TempFileName);
 
-	BinaryData = FormAttributeToValue("Object").GetTemplate("VanessaEditor");
-	ZipFileReader = New ZipFileReader(BinaryData.OpenStreamForRead());
+	ZipFileReader = New ZipFileReader(TemplateBinaryData.OpenStreamForRead());
 	For each ZipFileEntry In ZipFileReader.Items Do
 		ZipFileReader.Extract(ZipFileEntry, TempFileName, ZIPRestoreFilePathsMode.Restore);
 		BinaryData = New BinaryData(TempFileName + GetPathSeparator() + ZipFileEntry.FullName);


### PR DESCRIPTION
Вместо слеша при формировании пути надо использовать GetPathSeparator() для корректной работы на windows и mac