### PR TITLE
Отправка событий для 1С без предварительного накопления очереди

### DIFF
--- a/example/VAEditorSample/Forms/MainForm/Ext/Form/Module.bsl
+++ b/example/VAEditorSample/Forms/MainForm/Ext/Form/Module.bsl
@@ -630,12 +630,22 @@ EndProcedure
 Procedure VanessaEditorOnClick(Item, EventData, StandardProcessing)
 
 	Element = EventData.Element;
-	If Element.id = "VanessaEditorEventForwarder" Then
-		While (True) Do
-			msg = DefaultView().popVanessaMessage();
-			If (msg = Undefined) Then Break; EndIf;
-			VanessaEditorOnReceiveEventHandler(msg.editor, msg.type, msg.data);
-		EndDo;
+	If Element.id = "VanessaEditorEventForwarder" Then      
+		StandardProcessing = false;
+		If EventData.Event.type <> "click" Then
+			Return;
+		EndIf;
+		EventDataFor1C = EventData.Event.detail;
+		
+		If EventDataFor1C = Undefined Или TypeOf(EventDataFor1C) = Type("Число") Then
+			Return;
+		EndIf;
+		EventType = EventDataFor1C.name; //Строка
+		Data = EventDataFor1C.data; // Неопределено, Строка, Произвольный
+		If Not ValueIsFilled(EventType) Then
+			Return;
+		EndIf;
+		VanessaEditorOnReceiveEventHandler(EventDataFor1C.editor, EventType, Data);
 	ElsIf CharCode(Element.innerText, 1) = 60020 Then
 		Message(Element.title);
 	ElsIf CharCode(Element.innerText, 1) = 60277 Then

--- a/src/common.ts
+++ b/src/common.ts
@@ -155,7 +155,7 @@ export class EventsManager {
     // tslint:disable-next-line: no-console
     console.debug("fireEvent:", event, arg);
 
-    emitEventTo1C(event, arg, undefined);
+    emitEventTo1C(event, arg, this.owner, undefined);
   }
 
   public static fireEvent(
@@ -165,6 +165,6 @@ export class EventsManager {
   ) {
     // tslint:disable-next-line: no-console
     console.debug("fireEvent:", event, arg);
-    emitEventTo1C(event, arg, undefined);
+    emitEventTo1C(event, arg, editor, undefined);
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -109,17 +109,17 @@ function emitEventTo1C(
     event.stopPropagation();
   }
 
-  let eventData = data || "";
-  if (typeof eventData === "object") {
-    eventData = JSON.stringify(eventData);
-  }
+  // let eventData = data || "";
+  // if (typeof eventData === "object") {
+  //   eventData = JSON.stringify(eventData);
+  // }
   let lastEvent = new CustomEvent("click", {
     bubbles: true,
     cancelable: true,
     composed: false,
     detail: {
       name: name,
-      data: eventData,
+      data: data,
       editor,
     },
   });


### PR DESCRIPTION
Позволит убрать лишние обращения к полю HTML в обработке событий, что может приводить к вылетам и ошибкам в некоторых окружениях
Например, https://github.com/Pr-Mex/vanessa-automation/pull/2265

 