### PR TITLE
cleanup: удалить два мёртвых приватных метод

### DIFF
--- a/src/languages/turbo-gherkin/completion.ts
+++ b/src/languages/turbo-gherkin/completion.ts
@@ -1,5 +1,5 @@
 import { getLineMaxColumn, getLineMinColumn, IWorkerContext } from './common';
-import { VAStepData, VAStepInfo } from './steplist';
+import { VAStepData } from './steplist';
 
 export function getCompletions(
   ctx: IWorkerContext,

--- a/src/languages/turbo-gherkin/provider.ts
+++ b/src/languages/turbo-gherkin/provider.ts
@@ -155,10 +155,6 @@ export class VanessaGherkinProvider {
     this.createTheme1C();
   }
 
-  private clearObject(target: Object) {
-    Object.keys(target).forEach(key => delete target[key]);
-  }
-
   private clearArray(target: Array<any>) {
     target.splice(0, target.length);
   }

--- a/src/languages/turbo-gherkin/stepline.ts
+++ b/src/languages/turbo-gherkin/stepline.ts
@@ -125,11 +125,6 @@ export class VAStepLine {
     ).map(w => w.text);
   }
 
-  private keypair(ctx: IWorkerContext): string {
-    let keyword = this.keyword.trim().replace(/\s+/, " ").toLowerCase();
-    return ctx.keypairs[keyword];
-  }
-
   public checkSyntax(
     ctx: IWorkerContext,
     lineNumber: number,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,6 @@
 import { VanessaEditor } from "./vanessa-editor";
 import { VanessaEditorEvent } from "./common";
-import { IRange, IDisposable } from "monaco-editor";
+import { IDisposable } from "monaco-editor";
 
 import { SubcodeWidget } from "./widgets/subcode";
 import { ErrorWidget } from "./widgets/error";

--- a/src/widgets/image.ts
+++ b/src/widgets/image.ts
@@ -1,6 +1,3 @@
-import { VanessaEditor } from "../vanessa-editor";
-import { WidgetBase } from "./base";
-
 export class ImageWidget implements monaco.editor.IViewZone {
 
   public id: string;

--- a/src/widgets/subcode.ts
+++ b/src/widgets/subcode.ts
@@ -1,11 +1,11 @@
 import { WidgetBase } from "./base";
 import { RuntimeManager, IBreakpoint, Breakpoint } from "../runtime";
-import { SubcodeLine, RuntileGlyphs, BreakpointState } from "./subline";
+import { SubcodeLine, BreakpointState } from "./subline";
 import { getCodeFolding } from '../languages/turbo-gherkin/folding'
 import { language as gherkin } from '../languages/turbo-gherkin/configuration'
 import * as dom from 'monaco-editor/esm/vs/base/browser/dom';
 import { VanessaGherkinProvider } from "../languages/turbo-gherkin/provider";
-import { VAIndent, VAToken } from "../languages/turbo-gherkin/common";
+import { VAIndent } from "../languages/turbo-gherkin/common";
 import { getModelTokens } from "../languages/turbo-gherkin/model";
 
 const $ = dom.$;


### PR DESCRIPTION
Удалить два приватных метода, у которых 0 вызовов нигде в репо:

  * `keypair()` в `src/languages/turbo-gherkin/stepline.ts` — возвращал парное закрывающее слово для keyword'а строки (`Если` → `Тогда`). После рефакторинга на regex-based матчинг через `ctx.matcher.keypairs.forEach` остался без вызывающих (см. `checkSyntax` ниже в том же файле).
  * `clearObject()` в `src/languages/turbo-gherkin/provider.ts` — близнец `clearArray()`. Для сброса объектов в коде везде используется прямой `this._x = {}`, а `clearArray` для массивов сохранили (важен referential identity через `splice`). `clearObject` так и не был задействован.
 
Дополнительно удалены 6 неиспользуемых импортов в 4 файлах:
  * `runtime.ts`: `IRange`
  * `languages/turbo-gherkin/completion.ts`: `VAStepInfo`
  * `widgets/image.ts`: `VanessaEditor`, `WidgetBase`
  * `widgets/subcode.ts`: `RuntileGlyphs`, `VAToken`
 