### PR TITLE
chore: обновить build/test зависимости и поднять минимум Node до 20

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ configuration: Release
 platform: x64
 
 environment:
-  nodejs_version: "18"
+  nodejs_version: "20"
   KEY_1CV8T:
     secure: OolAVEKkEg1cGCpG/VK2FaM0LWrPgMR/Kn4nTLYyKR0=
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "vanessa-automation-editor",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vanessa-automation-editor",
-			"version": "1.3.6",
+			"version": "1.3.7",
 			"license": "BSD 3-Clause License",
 			"dependencies": {
-				"autoprefixer": "^9.8.8",
+				"autoprefixer": "^10.5.0",
 				"monaco-editor": "^0.30.1",
 				"monaco-editor-nls": "^2.0.0",
 				"postcss-base64": "^0.7.1",
@@ -17,23 +17,23 @@
 				"string-replace-loader": "^2.3.0"
 			},
 			"devDependencies": {
-				"@types/mocha": "^9.1.1",
-				"@vscode/codicons": "0.0.32",
+				"@types/mocha": "^10.0.10",
+				"@vscode/codicons": "0.0.45",
 				"babel-cli": "^6.26.0",
 				"babel-core": "^6.26.3",
 				"babel-loader": "^8.3.0",
 				"babel-preset-env": "^1.7.0",
-				"chai": "^4.3.7",
+				"chai": "^4.5.0",
 				"clean-webpack-plugin": "^4.0.0",
 				"css-loader": "^2.1.1",
 				"expect": "^27.5.1",
 				"html-webpack-plugin": "^4.5.2",
 				"jaro-winkler": "^0.2.8",
 				"jest-environment-jsdom-fourteen": "^1.0.1",
-				"mocha": "^9.2.2",
+				"mocha": "^10.8.2",
 				"postcss": "^8.4.21",
 				"postcss-alter-property-value": "^1.1.3",
-				"postcss-loader": "^3.0.0",
+				"postcss-loader": "^4.3.0",
 				"raw-loader": "^4.0.2",
 				"requirejs": "^2.3.6",
 				"run-script-os": "^1.1.1",
@@ -1673,11 +1673,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/mocha": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-			"integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-			"dev": true,
-			"license": "MIT"
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+			"integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+			"dev": true
 		},
 		"node_modules/@types/node": {
 			"version": "22.13.1",
@@ -1688,6 +1687,12 @@
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
+		},
+		"node_modules/@types/parse-json": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+			"dev": true
 		},
 		"node_modules/@types/source-list-map": {
 			"version": "0.1.6",
@@ -1818,19 +1823,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/@vscode/codicons": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.32.tgz",
-			"integrity": "sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==",
-			"dev": true,
-			"license": "CC-BY-4.0"
+			"version": "0.0.45",
+			"resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
+			"integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.9.0",
@@ -2168,11 +2165,10 @@
 			}
 		},
 		"node_modules/ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -2596,57 +2592,38 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "9.8.8",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
-			"integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
-			"license": "MIT",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"dependencies": {
-				"browserslist": "^4.12.0",
-				"caniuse-lite": "^1.0.30001109",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"picocolors": "^0.2.1",
-				"postcss": "^7.0.32",
-				"postcss-value-parser": "^4.1.0"
+				"browserslist": "^4.28.2",
+				"caniuse-lite": "^1.0.30001787",
+				"fraction.js": "^5.3.4",
+				"picocolors": "^1.1.1",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"bin": {
 				"autoprefixer": "bin/autoprefixer"
 			},
-			"funding": {
-				"type": "tidelift",
-				"url": "https://tidelift.com/funding/github/npm/autoprefixer"
-			}
-		},
-		"node_modules/autoprefixer/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"license": "ISC"
-		},
-		"node_modules/autoprefixer/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"license": "MIT",
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": "^10 || ^12 || >=14"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/autoprefixer/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
+			"peerDependencies": {
+				"postcss": "^8.1.0"
 			}
 		},
 		"node_modules/available-typed-arrays": {
@@ -3612,6 +3589,17 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.30",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+			"integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3918,9 +3906,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3935,12 +3923,12 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -4104,42 +4092,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/caller-callsite": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-			"integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"callsites": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/caller-callsite/node_modules/callsites": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/caller-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-			"integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"caller-callsite": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4172,9 +4124,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001698",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001698.tgz",
-			"integrity": "sha512-xJ3km2oiG/MbNU8G6zIq6XRZ6HtAOVXsbOrP/blGazi52kc5Yy7b6sDA5O+FbROzRrV7BSTllLHuNvmawYUJjw==",
+			"version": "1.0.30001793",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4188,8 +4140,7 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			],
-			"license": "CC-BY-4.0"
+			]
 		},
 		"node_modules/capture-exit": {
 			"version": "2.0.0",
@@ -4771,67 +4722,46 @@
 			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"import-fresh": "^2.0.0",
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.13.1",
-				"parse-json": "^4.0.0"
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
 			}
 		},
-		"node_modules/cosmiconfig/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+		"node_modules/cosmiconfig/node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/import-fresh": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-			"integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"caller-path": "^2.0.0",
-				"resolve-from": "^3.0.0"
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
 			},
 			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"node": ">=8"
 			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/cosmiconfig/node_modules/resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+		"node_modules/cosmiconfig/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/create-ecdh": {
@@ -5450,11 +5380,10 @@
 			"license": "MIT"
 		},
 		"node_modules/diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -5694,10 +5623,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.96",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
-			"integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
-			"license": "ISC"
+			"version": "1.5.357",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+			"integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.6.1",
@@ -7666,6 +7594,18 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/fraction.js": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/rawify"
+			}
+		},
 		"node_modules/fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -8051,16 +7991,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
-		},
-		"node_modules/growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.x"
-			}
 		},
 		"node_modules/handle-thing": {
 			"version": "2.0.1",
@@ -8986,19 +8916,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/import-cwd": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
-			"integrity": "sha512-Ew5AZzJQFqrOV5BTW3EIoHAnoie1LojZLXKcCQ/yTRyVZosBhK1x1ViYjHGf5pAFOq8ZyChZp6m/fSN7pJyZtg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"import-from": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9014,29 +8931,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/import-from": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-			"integrity": "sha512-0vdnLL2wSGnhlRmzHJAg5JHjt1l2vYhzJ7tNLGbeVg0fse56tpGaH0uzH+r9Slej+BSXXEHvBKDEnVSLLE9/+w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve-from": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/import-from/node_modules/resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/import-local": {
@@ -9403,16 +9297,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/is-directory": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-dotfile": {
@@ -11006,6 +10890,12 @@
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"license": "MIT"
 		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
+		},
 		"node_modules/json-schema": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -11119,6 +11009,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/klona": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+			"integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -11141,6 +11040,12 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true
 		},
 		"node_modules/load-json-file": {
 			"version": "4.0.0",
@@ -11682,47 +11587,38 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-			"integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+			"version": "10.8.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+			"integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@ungap/promise-all-settled": "1.1.2",
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.3",
-				"debug": "4.3.3",
-				"diff": "5.0.0",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.2.0",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "4.1.0",
-				"log-symbols": "4.1.0",
-				"minimatch": "4.2.1",
-				"ms": "2.1.3",
-				"nanoid": "3.3.1",
-				"serialize-javascript": "6.0.0",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "8.1.1",
-				"which": "2.0.2",
-				"workerpool": "6.2.0",
-				"yargs": "16.2.0",
-				"yargs-parser": "20.2.4",
-				"yargs-unparser": "2.0.0"
+				"ansi-colors": "^4.1.3",
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^3.5.3",
+				"debug": "^4.3.5",
+				"diff": "^5.2.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^8.1.0",
+				"he": "^1.2.0",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^5.1.6",
+				"ms": "^2.1.3",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^6.5.1",
+				"yargs": "^16.2.0",
+				"yargs-parser": "^20.2.9",
+				"yargs-unparser": "^2.0.0"
 			},
 			"bin": {
 				"_mocha": "bin/_mocha",
-				"mocha": "bin/mocha"
+				"mocha": "bin/mocha.js"
 			},
 			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mochajs"
+				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/mocha/node_modules/anymatch": {
@@ -11750,6 +11646,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/mocha/node_modules/braces": {
@@ -11792,31 +11697,6 @@
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			}
-		},
-		"node_modules/mocha/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/mocha/node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/mocha/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -11877,22 +11757,20 @@
 			}
 		},
 		"node_modules/mocha/node_modules/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -11909,19 +11787,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/mocha/node_modules/has-flag": {
@@ -11997,13 +11862,12 @@
 			}
 		},
 		"node_modules/mocha/node_modules/minimatch": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-			"integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=10"
@@ -12165,19 +12029,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/nanoid": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
 		"node_modules/nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -12323,10 +12174,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-			"license": "MIT"
+			"version": "2.0.44",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+			"integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ=="
 		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
@@ -12364,15 +12214,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -12398,12 +12239,6 @@
 			"funding": {
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
-		},
-		"node_modules/num2fraction": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
-			"license": "MIT"
 		},
 		"node_modules/nwsapi": {
 			"version": "2.2.16",
@@ -13860,115 +13695,57 @@
 			}
 		},
 		"node_modules/postcss-loader": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
-			"integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
+			"integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"loader-utils": "^1.1.0",
-				"postcss": "^7.0.0",
-				"postcss-load-config": "^2.0.0",
-				"schema-utils": "^1.0.0"
+				"cosmiconfig": "^7.0.0",
+				"klona": "^2.0.4",
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^3.0.0",
+				"semver": "^7.3.4"
 			},
 			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/postcss-loader/node_modules/json5": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/postcss-loader/node_modules/loader-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-			"integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/postcss-loader/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/postcss-loader/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"node": ">= 10.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/postcss-loader/node_modules/postcss-load-config": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
-			"integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cosmiconfig": "^5.0.0",
-				"import-cwd": "^2.0.0"
+				"url": "https://opencollective.com/webpack"
 			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
+			"peerDependencies": {
+				"postcss": "^7.0.0 || ^8.0.1",
+				"webpack": "^4.0.0 || ^5.0.0"
 			}
 		},
 		"node_modules/postcss-loader/node_modules/schema-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-			"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.1.0",
-				"ajv-errors": "^1.0.0",
-				"ajv-keywords": "^3.1.0"
+				"@types/json-schema": "^7.0.8",
+				"ajv": "^6.12.5",
+				"ajv-keywords": "^3.5.2"
 			},
 			"engines": {
-				"node": ">= 4"
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/postcss-loader/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+		"node_modules/postcss-loader/node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
 			"dev": true,
-			"license": "BSD-3-Clause",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/postcss-modules-extract-imports": {
@@ -16110,11 +15887,10 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -18302,9 +18078,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-			"integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -18319,7 +18095,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -20587,11 +20362,10 @@
 			}
 		},
 		"node_modules/workerpool": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-			"integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-			"dev": true,
-			"license": "Apache-2.0"
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+			"dev": true
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
@@ -20765,10 +20539,9 @@
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-			"license": "ISC",
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"engines": {
 				"node": ">=10"
 			}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		}
 	],
 	"dependencies": {
-		"autoprefixer": "^9.8.8",
+		"autoprefixer": "^10.5.0",
 		"monaco-editor": "^0.30.1",
 		"monaco-editor-nls": "^2.0.0",
 		"postcss-base64": "^0.7.1",
@@ -43,23 +43,23 @@
 		"string-replace-loader": "^2.3.0"
 	},
 	"devDependencies": {
-		"@types/mocha": "^9.1.1",
-		"@vscode/codicons": "0.0.32",
+		"@types/mocha": "^10.0.10",
+		"@vscode/codicons": "0.0.45",
 		"babel-cli": "^6.26.0",
 		"babel-core": "^6.26.3",
 		"babel-loader": "^8.3.0",
 		"babel-preset-env": "^1.7.0",
-		"chai": "^4.3.7",
+		"chai": "^4.5.0",
 		"clean-webpack-plugin": "^4.0.0",
 		"css-loader": "^2.1.1",
 		"expect": "^27.5.1",
 		"html-webpack-plugin": "^4.5.2",
 		"jaro-winkler": "^0.2.8",
 		"jest-environment-jsdom-fourteen": "^1.0.1",
-		"mocha": "^9.2.2",
+		"mocha": "^10.8.2",
 		"postcss": "^8.4.21",
 		"postcss-alter-property-value": "^1.1.3",
-		"postcss-loader": "^3.0.0",
+		"postcss-loader": "^4.3.0",
 		"raw-loader": "^4.0.2",
 		"requirejs": "^2.3.6",
 		"run-script-os": "^1.1.1",
@@ -74,6 +74,6 @@
 		"webpack-dev-server": "^3.11.3"
 	},
 	"engines": {
-		"node": ">=8.10.0"
+		"node": ">=18.0.0"
 	}
 }


### PR DESCRIPTION
Пакет обновлений для build/test инфраструктуры — закрывает накопленные CVE в транзитивных deps mocha/chai/postcss и синхронизирует Node-target с актуальным LTS.
  
  ### Зависимости
  
  | Пакет | Было | Стало | Почему |
  |---|---|---|---|
  | `mocha` | ^9.2.2 | ^10.8.2 | security fixes в `js-yaml`, `diff`, и др. |
  | `@types/mocha` | ^9.1.1 | ^10.0.10 | синхронизация с mocha 10 |
  | `chai` | ^4.3.7 | ^4.5.0 | latest minor (5+ ESM-only — отложено) |
  | `@vscode/codicons` | 0.0.32 | 0.0.45 | patch-апдейт иконок |
  | `autoprefixer` | ^9.8.8 | ^10.5.0 | требует postcss 8 + postcss-loader 4 |
  | `postcss-loader` | ^3.0.0 | ^4.3.0 | нужно для autoprefixer 10 |

  **postcss-loader 4.3.0** — последняя версия с поддержкой `webpack@4` (v5+ требует `webpack@5`).
  
  ### Не тронуты намеренно
  
  * `ts-loader` — v9 требует `webpack: ^5`, отложено
  * `chai` major — v5/v6 [ESM-only](https://github.com/chaijs/chai/releases/tag/v5.0.0), потребует переписать `require('chai')` → `import` во всех `test/**/*.test.ts`
  
  ### Платформа
  
  * `appveyor.yml`: `nodejs_version: "18"` → `"20"` — Node 18 LTS истекает в апреле 2026, активный LTS теперь Node 20 (active до апреля 2026, потом maintenance до апреля 2028)
  * `package.json` `engines.node`: `>=8.10.0` → `>=18.0.0` — синхронизация с реально поддерживаемым диапазоном (mocha 10 требует Node 14+, autoprefixer 10 — Node 10+; ставим консервативно 18)
  
  ### Эффект
  
  | Метрика | До | После |
  |---|---|---|
  | `npm audit` total | 98 | **94** |
  | `npm run buildci` | ✅ | ✅ |
  | Bundle `app.js` | 16.4 MB | 15.7 MB (рост ~0.1 MB от новых deps в production-mode) |
  | Build time на Node 20 | — | **−1.8 с быстрее** (17.5 с vs 19.3 с) |

  Оставшиеся 28 critical — все из Babel 6, закрываются отдельной веткой `chore/remove-babel-6`.
  
  ### Проверка
  
  * `npm install` без ошибок на Node 18.17.1 и Node 20.20.2
  * `npm run buildci` чистая сборка
  * `npm run test` — dev-server стартует, в браузере все mocha-тесты зелёные