### PR TITLE
chore: включить tsconfig noImplicitReturns

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -58,7 +58,7 @@ export function initPage() {
   document.body.appendChild(domMain);
 }
 
-function getLanguage(filename: string): string {
+function getLanguage(filename: string): string | undefined {
   let ext = "." + filename.split(".").pop().toLowerCase();
   let languages = monaco.languages.getLanguages();
   for (let key in languages) {
@@ -66,6 +66,7 @@ function getLanguage(filename: string): string {
     if (lang.extensions == undefined) continue;
     if (lang.extensions.some((e) => e == ext)) return lang.id;
   }
+  return undefined;
 }
 
 export function createModel(

--- a/src/languages/turbo-gherkin/provider.ts
+++ b/src/languages/turbo-gherkin/provider.ts
@@ -295,7 +295,7 @@ export class VanessaGherkinProvider {
 
   public checkSyntax(m: monaco.editor.ITextModel, manager?: ISyntaxManager) {
     const model = m as IVanessaModel;
-    if (model.getLanguageId() != language.id) return;
+    if (model.getLanguageId() != language.id) return Promise.resolve();
     return postMessage<ISyntaxDecorations>(model, {
       type: MessageType.CheckSyntax,
       versionId: model.getVersionId(),

--- a/src/languages/turbo-gherkin/stepline.ts
+++ b/src/languages/turbo-gherkin/stepline.ts
@@ -17,7 +17,7 @@ export interface VAStepWord {
 function stepDecoration(
   step: VAStepData,
   lineNumber: number,
-): monaco.editor.IModelDeltaDecoration {
+): monaco.editor.IModelDeltaDecoration | undefined {
   let glyph = undefined;
   let style = undefined;
   switch (step.kind) {
@@ -33,6 +33,7 @@ function stepDecoration(
       inlineClassName: style,
     }
   };
+  return undefined;
 }
 
 function conditionDecoration(

--- a/src/languages/turbo-gherkin/worker.ts
+++ b/src/languages/turbo-gherkin/worker.ts
@@ -139,4 +139,5 @@ export function process(msg: WorkerMessage) {
         data: res
       };
   }
+  return undefined;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -402,7 +402,7 @@ export class RuntimeManager {
     return this.editor.getModel().getLineContent(lineNumber);
   }
 
-  public getCurrent(): IRuntimePosition {
+  public getCurrent(): IRuntimePosition | undefined {
     const model = this.editor.getModel();
     let decoration = this.currentDecorationIds[0];
     let range = decoration ? model.getDecorationRange(decoration) : undefined;
@@ -410,9 +410,10 @@ export class RuntimeManager {
     let widget = this.codeWidgets[this.currentCodeWidget] as SubcodeWidget;
     let lineNumber = widget ? widget.getCurrent() : undefined;
     if (lineNumber) return new RuntimePosition(lineNumber, widget.id);
+    return undefined;
   }
 
-  public setCurrent(lineNumber: number, codeWidget: string = ""): IRuntimePosition {
+  public setCurrent(lineNumber: number, codeWidget: string = ""): IRuntimePosition | undefined {
     const model = this.editor.getModel();
     this.currentDecorationIds = model.deltaDecorations(this.currentDecorationIds, []);
     let widget = this.codeWidgets[this.currentCodeWidget] as SubcodeWidget;
@@ -426,6 +427,7 @@ export class RuntimeManager {
         widget.setCurrent(lineNumber);
         return new RuntimePosition(lineNumber, codeWidget);
       }
+      return undefined;
     } else {
       if (lineNumber <= 0 || lineNumber > model.getLineCount()) return undefined;
       const oldDecorations = [];
@@ -450,7 +452,7 @@ export class RuntimeManager {
     }
   }
 
-  public next(): IRuntimePosition {
+  public next(): IRuntimePosition | undefined {
     let step = this.getCurrent();
     if (step == undefined) return this.setCurrent(1);
     if (step.codeWidget) {
@@ -462,6 +464,9 @@ export class RuntimeManager {
         lineNumber = widget.lineNumber(this.editor) + 1;
         return this.setCurrent(lineNumber);
       }
+      // widget was disposed (e.g. clearSubcode) — fall back to advancing on the editor line
+      let lineNumber = step.lineNumber + 1;
+      return this.setCurrent(lineNumber);
     } else {
       let decorations = this.editor.getLineDecorations(step.lineNumber);
       for (let id in this.codeWidgets) {
@@ -475,10 +480,11 @@ export class RuntimeManager {
     }
   }
 
-  public showError(lineNumber: number, codeWidget: string, data: string, text: string) {
+  public showError(lineNumber: number, codeWidget: string, data: string, text: string): string | undefined {
     if (codeWidget) {
       let widget = this.codeWidgets[codeWidget] as SubcodeWidget;
       if (widget) widget.showError(lineNumber, data, text);
+      return undefined;
     } else {
       let widget = new ErrorWidget(this.owner, data, text);
       let id = widget.show(this.editor, lineNumber);

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,8 @@
       "target": "es5",
       "module": "commonjs",
       "removeComments": true,
-      "resolveJsonModule": true
+      "resolveJsonModule": true,
+      "noImplicitReturns": true
   },
   "exclude": [
       "node_modules"

--- a/src/vanessa-tabs.ts
+++ b/src/vanessa-tabs.ts
@@ -265,7 +265,7 @@ class VanessaTabItem {
     return JSON.stringify(this.editor.editor.getOption(id));
   }
 
-  public get options(): string {
+  public get options(): string | undefined {
     if (this.editor.type === VAEditorType.CodeEditor) {
       const result = {};
       Object.keys(monaco.editor.EditorOption).forEach(id => {
@@ -274,6 +274,7 @@ class VanessaTabItem {
       });
       return JSON.stringify(result);
     }
+    return undefined;
   }
 
   public set options(value: string) {
@@ -334,6 +335,7 @@ export class VanessaTabs {
 
   public get current() {
     if (this.tabStack.length) return this.tabStack[this.tabStack.length - 1];
+    return undefined;
   }
 
   private key(original: string, modified: string = undefined) {
@@ -356,10 +358,11 @@ export class VanessaTabs {
   public find = (
     original: string = "",
     modified: string = "",
-  ): IVanessaEditor => {
+  ): IVanessaEditor | undefined => {
     const key = this.key(original, modified);
     let tab = this.findTab(t => t.key === key);
     if (tab) return tab.select();
+    return undefined;
   }
 
   private open(


### PR DESCRIPTION
[Флаг `noImplicitReturns`](https://www.typescriptlang.org/tsconfig#noImplicitReturns) ловит функции, объявленные как возвращающие `T`, у которых есть code-path, проваливающийся за конец без `return` — функция возвращает `undefined`, нарушая контракт.
  
  Найдено **11 точек**. Большинство — функции, которые по факту могут не возвращать значение; уточнены сигнатуры и добавлены явные `return undefined`.
  **Одна — реальный латентный баг** в `runtime.ts:next()`.
  
  ### Изменения по файлам

  * **`common.ts:getLanguage()`** — тип `string` → `string | undefined`. Когда расширение файла не сматчилось, функция всегда возвращала undefined; теперь это явный контракт. Caller (`createModel`) передаёт результат в `monaco.editor.createModel()`, который принимает undefined языка
  * **`stepline.ts:stepDecoration()`** — тип `IModelDeltaDecoration` → `IModelDeltaDecoration | undefined`
  * **`vanessa-tabs.ts`** — `get options()` → `string | undefined`, `get current()` + явный `return undefined`, `find` arrow → `IVanessaEditor |
  undefined`
  * **`runtime.ts:getCurrent()` / `setCurrent()`** — типы → `IRuntimePosition | undefined`
  * **`runtime.ts:showError()`** — добавлен явный тип возврата `string | undefined`
  * **`runtime.ts:next()`** — **реальный баг**: когда `step.codeWidget` ссылается на subcode-виджет, которого уже нет (например после `clearSubcode`), if-ветка проваливалась мимо return — 1С получала пустую позицию и не могла продвинуть выполнение. Добавлен fallback в ту же логику, что для шага без `codeWidget`
  * **`worker.ts:process()`** — ряд `break;` без return; `onmessage` в `provider.ts` это нормально обрабатывает (`msg.id && messageMap.get(msg.id)`), но noImplicitReturns ругается — добавлен `return undefined` после switch
  * **`provider.ts:checkSyntax()`** — ранний `return;` для не-Gherkin моделей превращён в `return Promise.resolve()`; функция теперь всегда возвращает Promise
  
  ### Проверка
  
  * `npx tsc --noEmit` для `src/` — без ошибок
  * `npm run buildci` проходит чисто
  * `npm run test` — все тесты зелёные
  * `dist/app.js` идентичен по размеру master

  ### Дальше
  
  Это первый из инкрементальных strict-флагов. План — добавлять остальные (`noImplicitAny`, `strictNullChecks`, etc.) отдельными PR.