### PR TITLE
chore: обновить webpack-dev-server 3.11.3 → 4.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"typescript": "^4.9.5",
 				"webpack": "^4.46.0",
 				"webpack-cli": "^4.10.0",
-				"webpack-dev-server": "^3.11.3"
+				"webpack-dev-server": "^4.15.2"
 			},
 			"engines": {
 				"node": ">=8.10.0"
@@ -942,7 +942,8 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
 			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -976,6 +977,87 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@types/body-parser": {
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+			"integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/bonjour": {
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
+			"integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/connect": {
+			"version": "3.4.38",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+			"integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/connect-history-api-fallback": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+			"integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express-serve-static-core": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/express": {
+			"version": "4.17.25",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+			"integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.33",
+				"@types/qs": "*",
+				"@types/serve-static": "^1"
+			}
+		},
+		"node_modules/@types/express-serve-static-core": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+			"integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
+		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+			"version": "4.19.8",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+			"integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
 		"node_modules/@types/glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -991,6 +1073,23 @@
 			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
 			"integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
 			"dev": true
+		},
+		"node_modules/@types/http-errors": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+			"integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/http-proxy": {
+			"version": "1.17.17",
+			"resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+			"integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.6",
@@ -1027,6 +1126,13 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
+		"node_modules/@types/mime": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+			"integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/minimatch": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-6.0.0.tgz",
@@ -1050,6 +1156,90 @@
 			"dev": true,
 			"dependencies": {
 				"undici-types": ">=7.24.0 <7.24.7"
+			}
+		},
+		"node_modules/@types/node-forge": {
+			"version": "1.3.14",
+			"resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+			"integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/qs": {
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/range-parser": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/serve-index": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
+			"integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express": "*"
+			}
+		},
+		"node_modules/@types/serve-static": {
+			"version": "1.15.10",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+			"integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-errors": "*",
+				"@types/node": "*",
+				"@types/send": "<1"
+			}
+		},
+		"node_modules/@types/serve-static/node_modules/@types/send": {
+			"version": "0.17.6",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+			"integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime": "^1",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/sockjs": {
+			"version": "0.3.36",
+			"resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
+			"integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/source-list-map": {
@@ -1111,6 +1301,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/yargs": {
@@ -1434,6 +1634,48 @@
 				"ajv": ">=5.0.0"
 			}
 		},
+		"node_modules/ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ajv-formats/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -1556,12 +1798,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/array-flatten": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
-			"dev": true
 		},
 		"node_modules/array-includes": {
 			"version": "3.1.9",
@@ -1774,23 +2010,17 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/async": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-			"dev": true
-		},
 		"node_modules/async-each": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
 			"integrity": "sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "individual",
 					"url": "https://paulmillr.com/funding/"
 				}
-			]
+			],
+			"optional": true
 		},
 		"node_modules/async-function": {
 			"version": "1.0.0",
@@ -2087,18 +2317,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/bonjour": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.1.tgz",
-			"integrity": "sha512-xONzj4PfpPJw6xSqCcT2SmQkBOXpUINUz3o3qXcWJwYlXbkZNcNaUae0o5lle7tKt4HHV6dTgkIRhAXZ3nBMsQ==",
+		"node_modules/bonjour-service": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+			"integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"array-flatten": "^2.1.0",
-				"deep-equal": "^1.0.1",
-				"dns-equal": "^1.0.0",
-				"dns-txt": "^2.0.2",
-				"multicast-dns": "^7.2.3",
-				"multicast-dns-service-types": "^1.1.0"
+				"fast-deep-equal": "^3.1.3",
+				"multicast-dns": "^7.2.5"
 			}
 		},
 		"node_modules/boolbase": {
@@ -2304,12 +2531,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-		},
-		"node_modules/buffer-indexof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
-			"dev": true
 		},
 		"node_modules/buffer-xor": {
 			"version": "1.0.3",
@@ -2907,10 +3128,11 @@
 			}
 		},
 		"node_modules/connect-history-api-fallback": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+			"integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
 			}
@@ -3385,26 +3607,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/deep-equal": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-			"integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-			"dev": true,
-			"dependencies": {
-				"is-arguments": "^1.1.1",
-				"is-date-object": "^1.0.5",
-				"is-regex": "^1.1.4",
-				"object-is": "^1.1.5",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.5.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3412,16 +3614,127 @@
 			"dev": true
 		},
 		"node_modules/default-gateway": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
-			"integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+			"integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"execa": "^1.0.0",
-				"ip-regex": "^2.1.0"
+				"execa": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">= 10"
+			}
+		},
+		"node_modules/default-gateway/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/default-gateway/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/default-gateway/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-gateway/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-gateway/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/default-gateway/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/default-gateway/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/default-gateway/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/define-data-property": {
@@ -3438,6 +3751,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/define-properties": {
@@ -3589,31 +3912,17 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/dns-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
-			"dev": true
-		},
 		"node_modules/dns-packet": {
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
 			"integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/dns-txt": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-			"integrity": "sha512-Ix5PrWjphuSoUXV/Zv5gaFHjnaJtb02F2+Si3Ht9dyJ87+Z/lMmy+dpNHtTGraNK958ndXq2i+GLkWsWHcKaBQ==",
-			"dev": true,
-			"dependencies": {
-				"buffer-indexof": "^1.0.0"
 			}
 		},
 		"node_modules/doctrine": {
@@ -4923,7 +5232,8 @@
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
 			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
@@ -4931,15 +5241,6 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"engines": {
 				"node": ">=0.8.x"
-			}
-		},
-		"node_modules/eventsource": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-			"integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/evp_bytestokey": {
@@ -5536,6 +5837,7 @@
 					"url": "https://github.com/sponsors/RubenVerborgh"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -5641,6 +5943,13 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/fs-monkey": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
+			"integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
+			"dev": true,
+			"license": "Unlicense"
 		},
 		"node_modules/fs-write-stream-atomic": {
 			"version": "1.0.10",
@@ -6227,10 +6536,21 @@
 			}
 		},
 		"node_modules/html-entities": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-			"integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
-			"dev": true
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/html-minifier-terser": {
 			"version": "5.1.1",
@@ -6332,6 +6652,7 @@
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
 			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"eventemitter3": "^4.0.0",
 				"follow-redirects": "^1.0.0",
@@ -6342,18 +6663,104 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-			"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"http-proxy": "^1.17.0",
-				"is-glob": "^4.0.0",
-				"lodash": "^4.17.11",
-				"micromatch": "^3.1.10"
+				"@types/http-proxy": "^1.17.8",
+				"http-proxy": "^1.18.1",
+				"is-glob": "^4.0.1",
+				"is-plain-obj": "^3.0.0",
+				"micromatch": "^4.0.2"
 			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"@types/express": "^4.17.13"
+			},
+			"peerDependenciesMeta": {
+				"@types/express": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/http-proxy-middleware/node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/http-proxy-middleware/node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/http-proxy-middleware/node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+			"integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/http-proxy-middleware/node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/http-proxy-middleware/node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
 		"node_modules/http-signature": {
@@ -6375,6 +6782,16 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
+		},
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.17.0"
+			}
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
@@ -6610,19 +7027,6 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"node_modules/internal-ip": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
-			"integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
-			"dev": true,
-			"dependencies": {
-				"default-gateway": "^4.2.0",
-				"ipaddr.js": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6655,21 +7059,6 @@
 				"loose-envify": "^1.0.0"
 			}
 		},
-		"node_modules/ip": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-			"integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-			"dev": true
-		},
-		"node_modules/ip-regex": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-			"integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6677,15 +7066,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/is-absolute-url": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-			"integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/is-accessor-descriptor": {
@@ -6697,22 +7077,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/is-arguments": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-			"dev": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -6905,6 +7269,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-extendable": {
@@ -7981,12 +8361,6 @@
 				"json-buffer": "3.0.1"
 			}
 		},
-		"node_modules/killable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
-			"integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
-			"dev": true
-		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -7994,6 +8368,24 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/launch-editor": {
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
+			"integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picocolors": "^1.1.1",
+				"shell-quote": "^1.8.3"
+			}
+		},
+		"node_modules/launch-editor/node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/levn": {
 			"version": "0.3.0",
@@ -8118,19 +8510,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/loglevel": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-			"integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6.0"
-			},
-			"funding": {
-				"type": "tidelift",
-				"url": "https://tidelift.com/funding/github/npm/loglevel"
-			}
-		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8242,6 +8621,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/memfs": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"dev": true,
+			"license": "Unlicense",
+			"dependencies": {
+				"fs-monkey": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/memory-fs": {
@@ -8359,6 +8751,16 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/minimalistic-assert": {
@@ -8684,6 +9086,7 @@
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
 			"integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"dns-packet": "^5.2.2",
 				"thunky": "^1.0.2"
@@ -8691,12 +9094,6 @@
 			"bin": {
 				"multicast-dns": "cli.js"
 			}
-		},
-		"node_modules/multicast-dns-service-types": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-			"integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ==",
-			"dev": true
 		},
 		"node_modules/nan": {
 			"version": "2.27.0",
@@ -8792,12 +9189,13 @@
 			}
 		},
 		"node_modules/node-forge": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+			"integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
 			"dev": true,
+			"license": "(BSD-3-Clause OR GPL-2.0)",
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 6.13.0"
 			}
 		},
 		"node_modules/node-int64": {
@@ -8994,22 +9392,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object-is": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -9183,16 +9565,51 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/opn": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"is-wsl": "^1.1.0"
+				"mimic-fn": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+			"integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open/node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/optionator": {
@@ -9278,15 +9695,17 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-			"integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"retry": "^0.12.0"
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-try": {
@@ -9404,7 +9823,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
 			"integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-			"devOptional": true
+			"optional": true
 		},
 		"node_modules/path-exists": {
 			"version": "3.0.0",
@@ -9679,19 +10098,6 @@
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
 			"dev": true
-		},
-		"node_modules/portfinder": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
-			"integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.2.6",
-				"debug": "^4.3.6"
-			},
-			"engines": {
-				"node": ">= 10.12"
-			}
 		},
 		"node_modules/posix-character-classes": {
 			"version": "0.1.1",
@@ -10371,12 +10777,6 @@
 				"node": ">=0.4.x"
 			}
 		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"dev": true
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10870,7 +11270,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.12",
@@ -10938,10 +11339,11 @@
 			}
 		},
 		"node_modules/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -11221,12 +11623,17 @@
 			"dev": true
 		},
 		"node_modules/selfsigned": {
-			"version": "1.10.14",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
-			"integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+			"integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"node-forge": "^0.10.0"
+				"@types/node-forge": "^1.3.0",
+				"node-forge": "^1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/semver": {
@@ -11372,12 +11779,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true
-		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -11517,6 +11918,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/shell-quote": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/side-channel": {
@@ -11755,34 +12169,6 @@
 				"faye-websocket": "^0.11.3",
 				"uuid": "^8.3.2",
 				"websocket-driver": "^0.7.4"
-			}
-		},
-		"node_modules/sockjs-client": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
-			"integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^3.2.7",
-				"eventsource": "^2.0.2",
-				"faye-websocket": "^0.11.4",
-				"inherits": "^2.0.4",
-				"url-parse": "^1.5.10"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://tidelift.com/funding/github/npm/sockjs-client"
-			}
-		},
-		"node_modules/sockjs-client/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.1"
 			}
 		},
 		"node_modules/sockjs/node_modules/uuid": {
@@ -12343,6 +12729,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -12625,7 +13021,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/timers-browserify": {
 			"version": "2.0.12",
@@ -13186,7 +13583,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-			"devOptional": true,
+			"optional": true,
 			"engines": {
 				"node": ">=4",
 				"yarn": "*"
@@ -13250,16 +13647,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dev": true,
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/url/node_modules/punycode": {
@@ -13709,443 +14096,250 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz",
-			"integrity": "sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"memory-fs": "^0.4.1",
-				"mime": "^2.4.4",
-				"mkdirp": "^0.5.1",
+				"colorette": "^2.0.10",
+				"memfs": "^3.4.3",
+				"mime-types": "^2.1.31",
 				"range-parser": "^1.2.1",
-				"webpack-log": "^2.0.0"
+				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 12.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
 				"webpack": "^4.0.0 || ^5.0.0"
 			}
 		},
-		"node_modules/webpack-dev-middleware/node_modules/memory-fs": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-			"integrity": "sha512-cda4JKCxReDXFXRqOHPQscuIYg1PvxbE2S2GP45rnwfEK+vZaXC8C1OFvdHIbgw0DLzowXGVoxLaAmlgRy14GQ==",
+		"node_modules/webpack-dev-middleware/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/webpack-dev-middleware/node_modules/mime": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+		"node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"dev": true,
-			"bin": {
-				"mime": "cli.js"
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/webpack-dev-middleware/node_modules/schema-utils": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "3.11.3",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
-			"integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
+			"version": "4.15.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"ansi-html-community": "0.0.8",
-				"bonjour": "^3.5.0",
-				"chokidar": "^2.1.8",
+				"@types/bonjour": "^3.5.9",
+				"@types/connect-history-api-fallback": "^1.3.5",
+				"@types/express": "^4.17.13",
+				"@types/serve-index": "^1.9.1",
+				"@types/serve-static": "^1.13.10",
+				"@types/sockjs": "^0.3.33",
+				"@types/ws": "^8.5.5",
+				"ansi-html-community": "^0.0.8",
+				"bonjour-service": "^1.0.11",
+				"chokidar": "^3.5.3",
+				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
-				"connect-history-api-fallback": "^1.6.0",
-				"debug": "^4.1.1",
-				"del": "^4.1.1",
-				"express": "^4.17.1",
-				"html-entities": "^1.3.1",
-				"http-proxy-middleware": "0.19.1",
-				"import-local": "^2.0.0",
-				"internal-ip": "^4.3.0",
-				"ip": "^1.1.5",
-				"is-absolute-url": "^3.0.3",
-				"killable": "^1.0.1",
-				"loglevel": "^1.6.8",
-				"opn": "^5.5.0",
-				"p-retry": "^3.0.1",
-				"portfinder": "^1.0.26",
-				"schema-utils": "^1.0.0",
-				"selfsigned": "^1.10.8",
-				"semver": "^6.3.0",
+				"connect-history-api-fallback": "^2.0.0",
+				"default-gateway": "^6.0.3",
+				"express": "^4.17.3",
+				"graceful-fs": "^4.2.6",
+				"html-entities": "^2.3.2",
+				"http-proxy-middleware": "^2.0.3",
+				"ipaddr.js": "^2.0.1",
+				"launch-editor": "^2.6.0",
+				"open": "^8.0.9",
+				"p-retry": "^4.5.0",
+				"rimraf": "^3.0.2",
+				"schema-utils": "^4.0.0",
+				"selfsigned": "^2.1.1",
 				"serve-index": "^1.9.1",
-				"sockjs": "^0.3.21",
-				"sockjs-client": "^1.5.0",
+				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"strip-ansi": "^3.0.1",
-				"supports-color": "^6.1.0",
-				"url": "^0.11.0",
-				"webpack-dev-middleware": "^3.7.2",
-				"webpack-log": "^2.0.0",
-				"ws": "^6.2.1",
-				"yargs": "^13.3.2"
+				"webpack-dev-middleware": "^5.3.4",
+				"ws": "^8.13.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 6.11.5"
+				"node": ">= 12.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^4.37.0 || ^5.0.0"
 			},
 			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				},
 				"webpack-cli": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/ansi-regex": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+		"node_modules/webpack-dev-server/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"color-convert": "^1.9.0"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
-			"engines": {
-				"node": ">=4"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/anymatch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+		"node_modules/webpack-dev-server/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/anymatch/node_modules/normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-			"dev": true,
-			"dependencies": {
-				"remove-trailing-separator": "^1.0.1"
+				"fast-deep-equal": "^3.1.3"
 			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/ipaddr.js": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+			"integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">= 10"
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/binary-extensions": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+		"node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
+			"license": "MIT"
 		},
-		"node_modules/webpack-dev-server/node_modules/chokidar": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+		"node_modules/webpack-dev-server/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.1",
-				"braces": "^2.3.2",
-				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.3",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"normalize-path": "^3.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.2.1",
-				"upath": "^1.1.1"
-			},
-			"optionalDependencies": {
-				"fsevents": "^1.2.7"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/cliui/node_modules/strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/webpack-dev-server/node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
-		},
-		"node_modules/webpack-dev-server/node_modules/glob-parent": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-			"integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-			"dev": true,
-			"dependencies": {
-				"is-glob": "^3.1.0",
-				"path-dirname": "^1.0.0"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/glob-parent/node_modules/is-glob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-			"integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-			"dev": true,
-			"dependencies": {
-				"is-extglob": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/import-local": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-			"dev": true,
-			"dependencies": {
-				"pkg-dir": "^3.0.0",
-				"resolve-cwd": "^2.0.0"
+				"glob": "^7.1.3"
 			},
 			"bin": {
-				"import-local-fixture": "fixtures/cli.js"
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/schema-utils": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/is-binary-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-			"integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
-			"dev": true,
-			"dependencies": {
-				"binary-extensions": "^1.0.0"
+				"node": ">= 10.13.0"
 			},
-			"engines": {
-				"node": ">=0.10.0"
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+		"node_modules/webpack-dev-server/node_modules/ws": {
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/readdirp": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
+				"node": ">=10.0.0"
 			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/resolve-cwd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-			"integrity": "sha512-ccu8zQTrzVr954472aUVPLEcB3YpKSYR3cg/3lo1okzobPBM+1INXBbBZlDbnI/hbEocnf8j0QVo43hQKrbchg==",
-			"dev": true,
-			"dependencies": {
-				"resolve-from": "^3.0.0"
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
 			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/string-width": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^7.0.1",
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^5.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/string-width/node_modules/strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/supports-color": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-			"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/yargs": {
-			"version": "13.3.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.2"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/yargs-parser": {
-			"version": "13.1.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
-		},
-		"node_modules/webpack-log": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-			"integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-colors": "^3.0.0",
-				"uuid": "^3.3.2"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/webpack-log/node_modules/ansi-colors": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/webpack-merge": {
@@ -14320,12 +14514,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/which-module": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-			"dev": true
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"typescript": "^4.9.5",
 		"webpack": "^4.46.0",
 		"webpack-cli": "^4.10.0",
-		"webpack-dev-server": "^3.11.3"
+		"webpack-dev-server": "^4.15.2"
 	},
 	"engines": {
 		"node": ">=8.10.0"


### PR DESCRIPTION
v3 (2020) тянет уязвимые `express@4`, `http-proxy-middleware` и др. транзитивно. v4 закрывает security-проблемы из этой ветки.

### Почему v4, а не v5

[Peer dependencies](https://www.npmjs.com/package/webpack-dev-server):
* `webpack-dev-server@4` → `webpack: ^4.37.0 || ^5.0.0` — **совместимо с нашим webpack@4**
* `webpack-dev-server@5` → `webpack: ^5.0.0` only — потребует апгрейд webpack 4→5 (отдельная итерация)

## Эффект

* Только `devDependency` — production-bundle не меняется
* `app.js` после `npm run buildci` идентичен master (16 401 709 байт)
* Закрытие CVE из express/http-proxy-middleware через v3

### Проверка

* `npm install` без ошибок
* `npm run buildci` — чистая сборка, 20 с
* `npm run test` — dev-server стартует на `http://localhost:4000/`, страницы (`/`, `/test.html`) отвечают `200 OK`, в браузере **все mocha-тесты зелёные**
* HMR WebSocket работает на `ws://localhost:4000/ws`