### PR TITLE
fix: вернуть иконки после webpack 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,22 @@
 			"version": "1.3.7",
 			"license": "BSD 3-Clause License",
 			"dependencies": {
+				"buffer": "^6.0.3",
+				"jaro-winkler": "^0.2.8",
 				"monaco-editor": "^0.30.1",
-				"monaco-editor-nls": "^2.0.0"
+				"monaco-editor-nls": "^2.0.0",
+				"process": "^0.11.10"
 			},
 			"devDependencies": {
 				"@types/mocha": "^10.0.10",
 				"@vscode/codicons": "0.0.45",
 				"autoprefixer": "^10.5.0",
-				"buffer": "^6.0.3",
 				"chai": "^4.5.0",
 				"css-loader": "^7.1.4",
 				"html-webpack-plugin": "^5.6.0",
-				"jaro-winkler": "^0.2.8",
 				"mocha": "^10.8.2",
 				"postcss": "^8.5.15",
 				"postcss-loader": "^8.2.1",
-				"process": "^0.11.10",
 				"run-script-os": "^1.1.1",
 				"standard": "^16.0.4",
 				"stream-browserify": "^3.0.0",
@@ -1493,7 +1493,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1658,7 +1657,6 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
 			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4352,7 +4350,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5000,8 +4997,7 @@
 		"node_modules/jaro-winkler": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/jaro-winkler/-/jaro-winkler-0.2.8.tgz",
-			"integrity": "sha512-yr+mElb6dWxA1mzFu0+26njV5DWAQRNTi5pB6fFMm79zHrfAs3d0qjhe/IpZI4AHIUJkzvu5QXQRWOw2O0GQyw==",
-			"dev": true
+			"integrity": "sha512-yr+mElb6dWxA1mzFu0+26njV5DWAQRNTi5pB6fFMm79zHrfAs3d0qjhe/IpZI4AHIUJkzvu5QXQRWOw2O0GQyw=="
 		},
 		"node_modules/jest-worker": {
 			"version": "27.5.1",
@@ -6473,7 +6469,6 @@
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.6.0"
 			}

--- a/package.json
+++ b/package.json
@@ -35,22 +35,22 @@
 		}
 	],
 	"dependencies": {
+		"buffer": "^6.0.3",
+		"jaro-winkler": "^0.2.8",
 		"monaco-editor": "^0.30.1",
-		"monaco-editor-nls": "^2.0.0"
+		"monaco-editor-nls": "^2.0.0",
+		"process": "^0.11.10"
 	},
 	"devDependencies": {
 		"@types/mocha": "^10.0.10",
 		"@vscode/codicons": "0.0.45",
 		"autoprefixer": "^10.5.0",
-		"buffer": "^6.0.3",
 		"chai": "^4.5.0",
 		"css-loader": "^7.1.4",
 		"html-webpack-plugin": "^5.6.0",
-		"jaro-winkler": "^0.2.8",
 		"mocha": "^10.8.2",
 		"postcss": "^8.5.15",
 		"postcss-loader": "^8.2.1",
-		"process": "^0.11.10",
 		"run-script-os": "^1.1.1",
 		"standard": "^16.0.4",
 		"stream-browserify": "^3.0.0",

--- a/src/media/debug.css
+++ b/src/media/debug.css
@@ -1,37 +1,37 @@
 .debug-breakpoint-glyph {
-  background: url('src/media/debug-breakpoint.svg') center center no-repeat;
+  background: url('./debug-breakpoint.svg') center center no-repeat;
 }
 
 .debug-breakpoint-disabled-glyph {
-  background: url('src/media/debug-breakpoint-disabled.svg') center center no-repeat;
+  background: url('./debug-breakpoint-disabled.svg') center center no-repeat;
 }
 
 .debug-breakpoint-hint-glyph {
-  background: url('src/media/debug-breakpoint-hint.svg') center center no-repeat;
+  background: url('./debug-breakpoint-hint.svg') center center no-repeat;
 }
 
 .debug-breakpoint-unverified-glyph {
-  background: url('src/media/debug-breakpoint-unverified.svg') center center no-repeat;
+  background: url('./debug-breakpoint-unverified.svg') center center no-repeat;
 }
 
 .debug-current-step-glyph {
-  background: url('src/media/debug-current-arrow.svg') center center no-repeat;
+  background: url('./debug-current-arrow.svg') center center no-repeat;
 }
 
 .debug-stackframe-glyph {
-  background: url('src/media/debug-stackframe-arrow.svg') center center no-repeat;
+  background: url('./debug-stackframe-arrow.svg') center center no-repeat;
 }
 
 .debug-breakpoint-glyph.debug-stackframe-glyph {
-  background: url('src/media/debug-stackframe-and-breakpoint.svg') center center no-repeat;
+  background: url('./debug-stackframe-and-breakpoint.svg') center center no-repeat;
 }
 
 .debug-breakpoint-unverified-glyph.debug-stackframe-glyph {
-  background: url('src/media/debug-stackframe-and-breakpoint.svg') center center no-repeat;
+  background: url('./debug-stackframe-and-breakpoint.svg') center center no-repeat;
 }
 
 .debug-breakpoint-glyph.debug-current-step-glyph {
-  background: url('src/media/debug-current-and-breakpoint.svg') center center no-repeat;
+  background: url('./debug-current-and-breakpoint.svg') center center no-repeat;
 }
 
 .monaco-editor .selected-text {
@@ -158,7 +158,7 @@ body[data-theme="vs-dark"] .vanessa-subcode-underline>span {
 }
 
 .vanessa-code-border.vanessa-use-breakpoints div.cgmr:hover:not(.debug-breakpoint-glyph):not(.debug-breakpoint-unverified-glyph) {
-  background: url('src/media/debug-breakpoint-hint.svg') center center no-repeat;
+  background: url('./debug-breakpoint-hint.svg') center center no-repeat;
 }
 
 .vanessa-code-widget .vanessa-code-lines {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,8 +37,7 @@ module.exports = (env, argv) => {
     module: {
       parser: {
         javascript: {
-          worker: false,
-          url: false
+          worker: false
         }
       },
       rules: [


### PR DESCRIPTION
После #180 во встроенном WebKit 1С пропали иконки: шрифт codicon и debug-глифы (брейкпоинты, стрелка текущего шага).

**Причина** — двойная:

1. `parser.javascript.url: false` в `webpack.config.js` отключал обработку `new URL()`, на которую css-loader v7 опирается при разрешении CSS `url()`. В итоге `url(./codicon.ttf)` и `url(...svg)` компилировались в битый `new URL('...', 'file:///.../node_modules/...')`, а правило `asset/inline` для `.ttf`/`.svg` не срабатывало — внутри 1С этих файлов нет.
2. В `debug.css` пути заданы от корня проекта (`url('src/media/X.svg')`), а css-loader резолвит их относительно самого CSS-файла.

**Фикс:**

- убран `url: false` (`worker: false` оставлен — воркеры по-прежнему идут через blob, состав файлов `dist` не меняется);
- пути в `debug.css` сделаны относительными (`./X.svg`).

Шрифт и SVG снова инлайнятся в `data:` URI.

**Заодно:** `buffer`, `process`, `jaro-winkler` перенесены из `devDependencies` в `dependencies` — они реально попадают в runtime-бандл `app.js` (`Buffer`/`process` через `ProvidePlugin` для monaco VSBuffer и воркеров; `jaro-winkler` — fuzzy-match в quickfix). На сборку не влияет (`private: true`), но корректнее документирует runtime-зависимости. `util` и `stream-browserify` оставлены в devDeps — они нужны mocha в тест-бандле.