### PR TITLE
fix: совместимость monaco 0.55 с WebKit 1С — буфер обмена, настройки редактора, markdown

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ self.MonacoEnvironment = {
 };
 
 import "./polyfills"; // ПЕРВЫМ: queueMicrotask/ResizeObserver до загрузки monaco
+import "./product-service"; // регистрация IProductService до StandaloneServices (нужен paste)
 import "./media/debug";
 import "./media/tabs";
 import "./media/welcome";

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -228,6 +228,16 @@ if (typeof _self.ResizeObserver !== 'function') {
     while ((m = rx.exec(str)) !== null) { out.push(m); if (m[0] === '') rx.lastIndex++; }
     return out[Symbol.iterator]();
   });
+  // String.prototype.trimStart/trimEnd (ES2019, Safari 12) — движок 1С (~Safari 11)
+  // их лишён. marked (markdown-рендер monaco 0.55) зовёт line.trimEnd() в list-
+  // токенизаторе (Tokenizer.list, ×3) при разборе ЛЮБОГО списка → TypeError рушит
+  // renderMarkdown СИНХРОННО в конструкторе VanessaViwer → markdown-вкладки (список
+  // уроков, MD-файлы, интерактивная справка) не открываются (VanessaTabs.count()=0).
+  // Код-редактор не затронут (markdown не рендерит). esbuild строковые методы не полифилит.
+  def(String.prototype, 'trimStart', function (this: string) { return String(this).replace(/^\s+/, ''); });
+  def(String.prototype, 'trimEnd', function (this: string) { return String(this).replace(/\s+$/, ''); });
+  def(String.prototype, 'trimLeft', (String.prototype as any).trimStart);
+  def(String.prototype, 'trimRight', (String.prototype as any).trimEnd);
 })();
 
 // Object.fromEntries (ES2019, Safari 12.1) / Promise.allSettled (ES2020, Safari 13)

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -71,20 +71,32 @@ if (typeof _self.FinalizationRegistry !== 'function') {
 // `navigator.clipboard.write([new ClipboardItem(...)])` СРАЗУ при создании
 // сервиса (Event.runAndSubscribe) → ReferenceError убивает editor.create()
 // (проявляется только в WebKit, в Chrome isSafari=false — путь не берётся).
-// Стабы: ClipboardItem-обёртка + no-op async-clipboard (копирование этим путём
-// не работает, но редактор создаётся; автотест буфер обмена не проверяет).
-if (typeof _self.ClipboardItem !== 'function') {
-  _self.ClipboardItem = function (items: any) {
-    this.items = items;
-    // monaco передаёт сюда DeferredPromise.p; при отмене (новый клик/закрытие
-    // вкладки) он реджектится Canceled. Настоящий ClipboardItem его потребляет,
-    // наш стаб — нет, поэтому гасим, иначе unhandledrejection каскадит в mocha.
-    for (var k in items) {
-      if (items[k] && typeof items[k].then === 'function') {
-        items[k].then(function () {}, function () {});
-      }
+// Раньше тут стояли no-op-стабы, но monaco 0.55 на paste
+// (editor.action.clipboardPasteAction → BrowserClipboardService.readText, ветка
+// isWeb) читает именно navigator.clipboard.readText(), тогда как copy/cut пишут
+// текст через DOM-событие execCommand. No-op readText() → '' → кнопка «Вставить»
+// вставляла пусто. Держим собственный in-memory буфер и пишем в него из ВСЕХ путей
+// monaco: writeText, write([ClipboardItem]) (WebKit-workaround отдаёт текст через
+// promise внутри ClipboardItem) и перехват DOM copy/cut. readText отдаёт буфер —
+// кнопки Вырезать/Копировать/Вставить снова работают (как на monaco 0.30).
+var _clipboard = { text: '' };
+function _grabClipboardItems(items: any) {
+  for (var k in items) {
+    var v = items[k];
+    if (v && typeof v.then === 'function') {
+      // monaco передаёт DeferredPromise.p; при отмене он реджектится Canceled —
+      // гасим (иначе unhandledrejection каскадит в mocha), а текст забираем в буфер.
+      v.then(function (val: any) {
+        if (typeof val === 'string') _clipboard.text = val;
+        else if (val && typeof val.text === 'function') { try { val.text().then(function (t: any) { _clipboard.text = String(t); }, function () {}); } catch (e) {} }
+      }, function () {});
+    } else if (typeof v === 'string') {
+      _clipboard.text = v;
     }
-  };
+  }
+}
+if (typeof _self.ClipboardItem !== 'function') {
+  _self.ClipboardItem = function (items: any) { this.items = items; _grabClipboardItems(items); };
 }
 try {
   var _nav: any = _self.navigator;
@@ -94,12 +106,30 @@ try {
     }
     var _clip: any = _nav.clipboard;
     if (_clip) {
-      if (typeof _clip.write !== 'function') _clip.write = function () { return Promise.resolve(); };
-      if (typeof _clip.writeText !== 'function') _clip.writeText = function () { return Promise.resolve(); };
-      if (typeof _clip.readText !== 'function') _clip.readText = function () { return Promise.resolve(''); };
+      if (typeof _clip.write !== 'function') _clip.write = function (data: any) {
+        try { for (var i = 0; i < (data || []).length; i++) { var it = data[i]; if (it && it.items) _grabClipboardItems(it.items); } } catch (e) { /* ignore */ }
+        return Promise.resolve();
+      };
+      if (typeof _clip.writeText !== 'function') _clip.writeText = function (t: any) { _clipboard.text = (t == null ? '' : String(t)); return Promise.resolve(); };
+      if (typeof _clip.readText !== 'function') _clip.readText = function () { return Promise.resolve(_clipboard.text); };
     }
   }
 } catch (e) { /* ignore */ }
+// Мост DOM copy/cut → in-memory буфер. monaco кладёт скопированный текст в
+// ClipboardEvent.clipboardData (ClipboardEventUtils.setTextData) в обработчике
+// textarea; перехватываем на всплытии (document, bubble — после обработчика
+// редактора) и дублируем в буфер, чтобы readText на paste его увидел.
+if (typeof _self.addEventListener === 'function') {
+  var _grabClipboardEvent = function (e: any) {
+    try {
+      var cd = e && e.clipboardData;
+      var t = cd && typeof cd.getData === 'function' ? cd.getData('text/plain') : '';
+      if (t) _clipboard.text = t;
+    } catch (err) { /* ignore */ }
+  };
+  _self.addEventListener('copy', _grabClipboardEvent, false);
+  _self.addEventListener('cut', _grabClipboardEvent, false);
+}
 
 if (typeof _self.queueMicrotask !== 'function') {
   const resolved = Promise.resolve();

--- a/src/product-service.ts
+++ b/src/product-service.ts
@@ -1,0 +1,23 @@
+// monaco 0.55: contrib/clipboard paste-действие (editor.action.clipboardPasteAction)
+// в своём run() вызывает accessor.get(IProductService). Но standalone-сборка monaco
+// этот сервис НЕ регистрирует (см. standaloneServices.js) → InstantiationService
+// бросает «[invokeFunction] unknown service 'productService'», run падает РАНЬШЕ
+// чтения буфера обмена, и кнопка «Вставить» не вставляет ничего. До 0.55 paste
+// productService не трогал — отсюда регрессия после апгрейда monaco.
+//
+// Регистрируем минимальную реализацию: paste использует только поле .quality
+// ('stable' → ветка телеметрии пропускается). Делаем это ДО инициализации
+// StandaloneServices (импорт в main.ts идёт сразу после полифилов), иначе
+// дескриптор не попадёт в реестр синглтонов.
+import { registerSingleton } from 'monaco-editor/esm/vs/platform/instantiation/common/extensions';
+import { IProductService } from 'monaco-editor/esm/vs/platform/product/common/productService';
+
+class StandaloneProductService {
+  declare readonly _serviceBrand: undefined;
+  readonly quality = 'stable';
+}
+
+// 3-й аргумент — supportsDelayedInstantiation: создаём сервис лениво, только когда
+// его действительно запросят (т.е. на первом paste).
+//@ts-ignore — IProductService здесь импортируется из внутреннего пути monaco без .d.ts
+registerSingleton(IProductService, StandaloneProductService, 1 /* InstantiationType.Delayed */);

--- a/src/vanessa-tabs.ts
+++ b/src/vanessa-tabs.ts
@@ -616,6 +616,25 @@ export class VanessaTabs {
   public select = (index: number) => this.tabStack[index].select();
   public set theme(arg: string) { StyleManager.theme = arg; }
   public get version(): string { return version }
-  public get options(): string { let o = monaco.editor.EditorOptions; return JSON.stringify(Object.keys(o).map(k => [k, o[k]])); }
+  public get options(): string {
+    const o = monaco.editor.EditorOptions;
+    return JSON.stringify(Object.keys(o).map(k => {
+      const opt: any = o[k];
+      const schema = opt && opt.schema;
+      // monaco 0.55: wrappingIndent/wrappingStrategy описывают schema как
+      // namespaced-обёртку { "editor.<name>": {...настоящая схема...} } — без
+      // верхнеуровневого type/anyOf. Форма 1С НастройкаРедактора при этом уходит
+      // в рекурсию по schema и валится на скалярном текущем значении опции
+      // («Значение не является значением объектного типа»). Разворачиваем обёртку
+      // к «голой» схеме (как у остальных enum-опций: type/enum/default напрямую).
+      // Объектные опции (bracketPairColorization и т.п.) имеют ключи вида
+      // editor.<name>.<subkey> — обёртка не разворачивается, рекурсия корректна.
+      if (schema && typeof schema === 'object' && !schema.type && !schema.anyOf) {
+        const inner = schema['editor.' + opt.name];
+        if (inner && typeof inner === 'object') return [k, { ...opt, schema: inner }];
+      }
+      return [k, opt];
+    }));
+  }
   public set options(value: string) { VanessaEditor.editors.forEach(e => e.options = value); this.editorOptions = JSON.parse(value); }
 }


### PR DESCRIPTION
## Контекст

После апгрейда monaco `0.30.1 → 0.55.1` (#182) при прогоне в реальной 1С
вскрылись три регрессии — все в устаревшем встроенном WebKit поля HTML 1С
(~Safari 11), который не обновляется вместе с платформой.

## Что починено

### 1. Настройки редактора (форма «НастройкаРедактора»)
В monaco 0.55 `wrappingIndent`/`wrappingStrategy` описывают schema как
namespaced-обёртку `{ "editor.<name>": {...} }` без верхнеуровневого
`type`/`anyOf`. Форма 1С уходила в рекурсию по schema и падала на скалярном
текущем значении опции — «Значение не является значением объектного типа».
Геттер `options` разворачивает обёртку к «голой» схеме (как у остальных
enum-опций). Объектные опции (`bracketPairColorization` и т.п.) с ключами
`editor.<name>.<subkey>` не разворачиваются — их рекурсия корректна.

### 2. Буфер обмена (кнопка «Вставить»)
Две причины:
- paste-действие 0.55 (`editor.action.clipboardPasteAction`) вызывает
  `accessor.get(IProductService)`, а standalone-сборка monaco этот сервис не
  регистрирует → `run()` падал до чтения буфера. Регистрируем минимальный
  `productService` (`quality='stable'`) **до** инициализации `StandaloneServices`.
- paste читает `navigator.clipboard.readText()`, тогда как copy/cut пишут текст
  через DOM `execCommand`. Прежний no-op `readText()` возвращал `''`. Заменён на
  in-memory буфер (`writeText`/`write`/`readText`) + мост на DOM-события
  `copy`/`cut`. Проверено в WebKit: cut → `'222\n333'`, paste → `'111\n222\n333'`.

### 3. Markdown-вкладки
`marked` (md-рендер monaco 0.55) зовёт `line.trimEnd()` в list-токенизаторе при
разборе любого списка. `trimStart`/`trimEnd` (ES2019, Safari 12) в движке 1С
отсутствуют → `TypeError` рушил `renderMarkdown` синхронно в конструкторе
`VanessaViwer`, и markdown-вкладки (список уроков, MD-файлы, интерактивная
справка) не открывались (`count=0`). Добавлен полифил `trimStart`/`trimEnd`
+ алиасы `trimLeft`/`trimRight`. Код-редактор не затронут (markdown не рендерит).

## Проверка
- `npx es-check es2019 dist/*.js` — проходит (новый код ≤ES2016).
- Автотест в реальной 1С 8.3.27 (WebKit): `VAEditorSample.epf /C autotest` —
  **46/46, `success.txt`**. Бандл грузится без `SyntaxError`.
- Ручная проверка в WebKit: настройки открываются, буфер обмена работает,
  markdown-вкладки рендерятся.

## Файлы
- `src/vanessa-tabs.ts` — разворот namespaced schema в геттере `options`
- `src/product-service.ts` (новый) + `src/main.ts` — регистрация `IProductService`
- `src/polyfills.ts` — in-memory clipboard, мост DOM copy/cut, `trimStart`/`trimEnd`
