### PR TITLE
fix: полифил ParentNode.replaceChildren (Safari 14) — diff-редактор в WebKit 1С

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -65,6 +65,31 @@ if (typeof _self.FinalizationRegistry !== 'function') {
   _self.FinalizationRegistry.prototype.unregister = function () { return false; };
 }
 
+// ParentNode.replaceChildren (Safari 14) — движок 1С его лишён. DiffEditorWidget
+// (0.52.2) зовёт element.replaceChildren() в movedBlocksLinesFeature (derived-
+// observable ПРИ СОЗДАНИИ diff-редактора) → TypeError рушит new VanessaDiffEditor:
+// diff-вкладка не открывается (git-сравнение, «сравнение настроек», уроки).
+// Также используется в hideUnchangedRegions/gutterFeature/hover.
+(function () {
+  function replaceChildren(this: any) {
+    while (this.firstChild) this.removeChild(this.firstChild);
+    for (var i = 0; i < arguments.length; i++) {
+      var child = arguments[i];
+      this.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+    }
+  }
+  [
+    typeof Element !== 'undefined' ? Element.prototype : null,
+    typeof Document !== 'undefined' ? Document.prototype : null,
+    typeof DocumentFragment !== 'undefined' ? DocumentFragment.prototype : null,
+  ].forEach(function (proto: any) {
+    if (proto && typeof proto.replaceChildren !== 'function') {
+      Object.defineProperty(proto, 'replaceChildren',
+        { value: replaceChildren, writable: true, configurable: true });
+    }
+  });
+})();
+
 // ClipboardItem (Safari 13.1) + async navigator.clipboard — движок 1С (WebKit
 // ~Safari 11.x) их лишён. monaco на WebKit-пути (isSafari/isWebkitWebView) в
 // BrowserClipboardService.installWebKitWriteTextWorkaround зовёт


### PR DESCRIPTION
## Проблема

`ParentNode.replaceChildren()` — DOM-API Safari 14+, во встроенном WebKit 1С
(поле HTML, ≈Safari 11) его нет. DiffEditorWidget monaco 0.52.2 вызывает
`element.replaceChildren()` в `movedBlocksLinesFeature` (derived-observable —
исполняется **при создании** diff-редактора) → TypeError рушит
`new VanessaDiffEditor`: diff-вкладка не открывается и не попадает в tabStack,
`VanessaTabs.current.isDiffEditor` остаётся Ложь, кнопки навигации по
различиям — скрытыми.

Проявления (CI vanessa-automation#2626, билд #1122 на 1.3.7.14 — оба
оставшихся падения из 1304 тестов):
- `Core/VAEditor/РаботаСGit` — «Не получилось нажать на кнопку
  `VanessaEditorPreviousDiff`: Невидимый пользователю элемент»;
- урок `Глава02/НастройкиВПанелиРедактораДругиеНастройки` — подсветка
  «Навигация по различиям» не находит скрытые кнопки.

Локально воспроизводится и на «Сравнить с другим фича-файлом» /
«сравнение настроек» — любой путь, создающий diff-редактор.

`replaceChildren` также используют `hideUnchangedRegionsFeature`,
`gutterFeature` и hover-виджеты.

## Решение

Полифил `replaceChildren` для `Element` / `Document` / `DocumentFragment`
в `src/polyfills.ts` (под guard, поведение по спецификации: очистить и
добавить узлы/строки).
