### PR TITLE
Мышь и ссылки в WebKit 1С: Pointer Events, hover, автодополнение (monaco 0.52.2)

### DIFF
--- a/src/1c-webkit-patch.js
+++ b/src/1c-webkit-patch.js
@@ -42,8 +42,13 @@ export function patchWebKit1C() {
       else {
         switch (e.keyCode) {
           case 27: {
-            tabs.onEscapePress()
-            return false
+            // до createVanessaTabs (или в одиночном редакторе) tabs нет —
+            // без guard'а Escape давал TypeError в keydown-обработчике
+            if (tabs) {
+              tabs.onEscapePress()
+              return false
+            }
+            break
           }
         }
       }

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -245,13 +245,20 @@ if (typeof _self.ResizeObserver !== 'function') {
   });
   // String.prototype.matchAll (ES2020, Safari 13) — движок 1С лишён, monaco зовёт
   // matchAll (0.52.2: textModelSync — синк моделей с воркером). Возвращаем
-  // итератор массива всех совпадений.
+  // итератор массива всех совпадений. ВАЖНО: глобальный RegExp НЕ пересоздаём
+  // через конструктор — он в WebKit 1С отвергает named groups (?<name>), которые
+  // литерал-парсер принимает; итерируем сам объект с восстановлением lastIndex.
   def(String.prototype, 'matchAll', function (this: string, re: any) {
-    var rx = (re instanceof RegExp)
-      ? new RegExp(re.source, re.flags.indexOf('g') >= 0 ? re.flags : re.flags + 'g')
-      : new RegExp(re, 'g');
+    var rx: any, saved = 0, own = false;
+    if (re instanceof RegExp && re.flags.indexOf('g') >= 0) {
+      rx = re; own = true; saved = rx.lastIndex;
+    } else {
+      rx = (re instanceof RegExp) ? new RegExp(re.source, re.flags + 'g') : new RegExp(re, 'g');
+    }
     var str = String(this), out: any[] = [], m: any;
+    rx.lastIndex = 0;
     while ((m = rx.exec(str)) !== null) { out.push(m); if (m[0] === '') rx.lastIndex++; }
+    if (own) rx.lastIndex = saved;
     return out[Symbol.iterator]();
   });
   // String.prototype.trimStart/trimEnd (ES2019, Safari 12) — движок 1С (~Safari 11)
@@ -301,3 +308,173 @@ if (typeof (Promise as any).allSettled !== 'function') {
 if (typeof (Object as any).hasOwn !== 'function') {
   (Object as any).hasOwn = function (o: any, k: any) { return Object.prototype.hasOwnProperty.call(o, k); };
 }
+
+// Symbol.asyncIterator (ES2018, Safari 12) — AsyncIterableObject (monaco,
+// vs/base/common/async.js) объявляет метод по этому символу ПРИ ЗАГРУЗКЕ бандла;
+// без символа ключ вырождается в строку "undefined", и for await (hover:
+// HoverOperation) итератор не находит → TypeError на каждом наведении, monaco
+// гасит его try/catch → hover МОЛЧА мёртв. Symbol.for — чтобы ключ класса и
+// esbuild-хелпер __forAwait сошлись на одном символе.
+if (!(Symbol as any).asyncIterator) {
+  Object.defineProperty(Symbol, 'asyncIterator', {
+    value: Symbol.for('Symbol.asyncIterator'), configurable: true
+  });
+}
+
+// Promise.prototype.finally (ES2018, Safari 11.1) — monaco зовёт при резолве
+// айтема саджеста (suggest.js) и в cancelable-промисах (async.js: codelens,
+// формат, gotoSymbol) → на движке уровня 11.0 TypeError при первом открытии
+// автодополнения. Наш код finally не использует, mocha путь UI-виджета не
+// покрывает (completion-тесты зовут провайдер напрямую).
+if (typeof (Promise.prototype as any).finally !== 'function') {
+  (Promise.prototype as any).finally = function (cb: any) {
+    return this.then(
+      function (v: any) { return Promise.resolve(cb()).then(function () { return v; }); },
+      function (e: any) { return Promise.resolve(cb()).then(function () { throw e; }); });
+  };
+}
+
+// Element.prototype.toggleAttribute (Safari 12) — quick input (палитра команд F1,
+// переход к строке Ctrl+G) зовёт toggleAttribute('readonly', …) при показе поля
+// ввода (quickInputBox.js) → TypeError, палитра не открывается.
+if (typeof Element !== 'undefined' && typeof (Element.prototype as any).toggleAttribute !== 'function') {
+  (Element.prototype as any).toggleAttribute = function (name: string, force?: boolean) {
+    if (this.hasAttribute(name)) {
+      if (force) return true;
+      this.removeAttribute(name);
+      return false;
+    }
+    if (force === false) return false;
+    this.setAttribute(name, '');
+    return true;
+  };
+}
+
+// AggregateError (ES2021, Safari 14) — monaco кидает его при ≥2 ошибках в dispose
+// (lifecycle.js); без полифила ReferenceError МАСКИРУЕТ исходные ошибки при отладке.
+if (typeof (_self as any).AggregateError !== 'function') {
+  (_self as any).AggregateError = function AggregateError(errors: any, message?: string) {
+    var e: any = new Error(message);
+    e.name = 'AggregateError';
+    e.errors = Array.prototype.slice.call(errors || []);
+    return e;
+  };
+}
+
+// User Timing (performance.mark/measure) — monaco замеряет inputLatency на КАЖДЫЙ
+// кейстрок (textAreaInput). В Safari 11 API есть; стабы — страховка под другие
+// версии WebKit 1С (8.3.14–8.3.2x). getEntriesByName обязан отдавать элемент с
+// duration: monaco читает getEntriesByName(...)[0].duration без проверки.
+(function () {
+  var perf: any = _self.performance;
+  if (!perf) { perf = _self.performance = {}; }
+  if (typeof perf.now !== 'function') {
+    var t0 = Date.now();
+    perf.now = function () { return Date.now() - t0; };
+  }
+  ['mark', 'measure', 'clearMarks', 'clearMeasures'].forEach(function (m) {
+    if (typeof perf[m] !== 'function') perf[m] = function () {};
+  });
+  if (typeof perf.getEntriesByName !== 'function') {
+    perf.getEntriesByName = function () { return [{ duration: 0, startTime: 0 }]; };
+  }
+})();
+
+// Blob.prototype.arrayBuffer (Safari 14) — monaco читает файл при drop в текст
+// (dnd.js); dropIntoEditor у нас выключен — чистая страховка через FileReader.
+if (typeof Blob !== 'undefined' && typeof (Blob.prototype as any).arrayBuffer !== 'function') {
+  (Blob.prototype as any).arrayBuffer = function () {
+    var blob = this;
+    return new Promise(function (resolve, reject) {
+      var r = new FileReader();
+      r.onload = function () { resolve(r.result); };
+      r.onerror = function () { reject(r.error); };
+      r.readAsArrayBuffer(blob);
+    });
+  };
+}
+
+// Pointer Events (Safari 13) — движок 1С их лишён, а monaco 0.52.2 строит на них
+// ВЕСЬ drag-интерактив: GlobalPointerMoveMonitor (выделение текста мышью, d&d
+// текста — mouseHandler.js), скроллбары и стрелки (стартуют прямо с 'pointerdown'
+// — abstractScrollbar.js/scrollbarArrow.js), минимап (minimap.js), overview ruler
+// диффа. Симптом в 1С: клики работают (они mousedown-овые), но любой drag мёртв,
+// а скроллбар/минимап мертвы целиком — их первичное событие не приходит вовсе.
+// Транслируем mouse → pointer на стадии capture document (порядок как в живых
+// браузерах: pointer* строго ПЕРЕД парным mouse*):
+//   mousedown → pointerdown, mousemove → pointermove, mouseup → pointerup.
+// Чего НЕ делаем намеренно:
+//  - setPointerCapture не эмулируем: единственный вызов —
+//    GlobalPointerMoveMonitor.startMonitoring — обёрнут в try/catch и при
+//    исключении слушает window, куда синтетика всплывает сама;
+//  - window.PointerEvent не определяем: BrowserFeatures.pointerEvents должен
+//    остаться false (десктоп → MouseHandler), конструктор никто не зовёт;
+//  - pointerleave/pointercancel не синтезируем: их потребитель
+//    (EditorPointerEventFactory) живёт только в PointerEventHandler (iOS).
+// По спеке preventDefault() на pointerdown подавляет compat-mousedown — зеркалим:
+// минимап/слайдер зовут его безусловно и рассчитывают, что mousedown не придёт
+// (иначе двойная обработка + увод фокуса из textarea редактора).
+(function () {
+  if (typeof _self.PointerEvent !== 'undefined') return; // современный движок — не вмешиваемся
+  if (typeof document === 'undefined' || typeof MouseEvent === 'undefined') return;
+
+  // MouseEvent.buttons (Safari 11.1) — GlobalPointerMoveMonitor сверяет e.buttons
+  // каждого pointermove с initialButtons и при расхождении обрывает drag. Если
+  // движок buttons не знает — ведём битовую маску сами через прототипный геттер:
+  // и оригиналы, и синтетика читают ОДИН источник, расхождение исключено.
+  var buttonsState = 0;
+  var BUTTON_BIT: any = { 0: 1, 1: 4, 2: 2 }; // e.button → бит e.buttons
+  if (!('buttons' in MouseEvent.prototype)) {
+    try {
+      Object.defineProperty(MouseEvent.prototype, 'buttons', {
+        get: function () { return buttonsState; }, configurable: true
+      });
+    } catch (e) { /* ignore */ }
+  }
+  _self.addEventListener('blur', function () { buttonsState = 0; }, false);
+
+  function synthPointer(type: string, src: any) {
+    var ev: any;
+    try {
+      ev = new MouseEvent(type, {
+        bubbles: true, cancelable: true, view: src.view || _self, detail: src.detail,
+        screenX: src.screenX, screenY: src.screenY, clientX: src.clientX, clientY: src.clientY,
+        ctrlKey: src.ctrlKey, altKey: src.altKey, shiftKey: src.shiftKey, metaKey: src.metaKey,
+        button: src.button, buttons: src.buttons, relatedTarget: null
+      } as any);
+    } catch (err) { // на случай движка без конструктора MouseEvent
+      ev = document.createEvent('MouseEvents');
+      ev.initMouseEvent(type, true, true, src.view || _self, src.detail,
+        src.screenX, src.screenY, src.clientX, src.clientY,
+        src.ctrlKey, src.altKey, src.shiftKey, src.metaKey, src.button, null);
+    }
+    // minimap/scrollbarArrow получают СЫРОЕ событие (addStandardDisposableListener
+    // не оборачивает pointerdown) и читают pointerId/buttons/offsetY/pageY —
+    // копируем недостающее own-свойствами (offsetX синтетики движок не считает).
+    function def(k: string, v: any) {
+      try { Object.defineProperty(ev, k, { value: v, configurable: true }); } catch (e) { /* ignore */ }
+    }
+    def('pointerId', 1); def('pointerType', 'mouse'); def('isPrimary', true);
+    def('offsetX', src.offsetX); def('offsetY', src.offsetY);
+    def('pageX', src.pageX); def('pageY', src.pageY);
+    return ev;
+  }
+
+  function translate(mouseType: string, pointerType: string, mirrorCancel: boolean) {
+    document.addEventListener(mouseType, function (src: any) {
+      if (mouseType === 'mousedown') buttonsState |= (BUTTON_BIT[src.button] || 0);
+      else if (mouseType === 'mouseup') buttonsState &= ~(BUTTON_BIT[src.button] || 0);
+      var target = src.target && src.target.dispatchEvent ? src.target : document;
+      var ev = synthPointer(pointerType, src);
+      target.dispatchEvent(ev);
+      if (mirrorCancel && ev.defaultPrevented) {
+        src.preventDefault();
+        if (src.stopImmediatePropagation) src.stopImmediatePropagation();
+        else src.stopPropagation();
+      }
+    }, true);
+  }
+  translate('mousedown', 'pointerdown', true);
+  translate('mousemove', 'pointermove', false);
+  translate('mouseup', 'pointerup', false);
+})();

--- a/src/vanessa-diff-editor.ts
+++ b/src/vanessa-diff-editor.ts
@@ -57,6 +57,10 @@ export class VanessaDiffEditor implements IVanessaEditor {
         invisibleCharacters: false,
         nonBasicASCII: false,
       },
+      // Как в vanessa-editor.ts: sticky scroll 0.52.2 включён по умолчанию —
+      // держим прежний UX; drop извне в поле 1С не нужен (неогороженные API).
+      stickyScroll: { enabled: false },
+      dropIntoEditor: { enabled: false },
     });
     this.editor.setModel(model);
     this.eventsManager = new EventsManager(this);

--- a/src/vanessa-editor.ts
+++ b/src/vanessa-editor.ts
@@ -147,6 +147,12 @@ export class VanessaEditor implements IVanessaEditor {
       invisibleCharacters: false,
       nonBasicASCII: false,
     },
+    // 0.52.2 включил sticky scroll по умолчанию — новый виджет поверх кода,
+    // которого не было на 0.30. Держим прежний UX.
+    stickyScroll: { enabled: false },
+    // Drop файлов извне в текст: путь читает dataTransfer.items/Blob.arrayBuffer
+    // без guard'ов (Safari 11.1/14) — в поле 1С не нужен, выкл.
+    dropIntoEditor: { enabled: false },
   };
 
   constructor(

--- a/src/vanessa-viewer.ts
+++ b/src/vanessa-viewer.ts
@@ -113,18 +113,32 @@ export class VanessaViwer implements IVanessaEditor {
     node.appendChild(this._domNode);
   }
 
+  // renderMarkdown 0.52.2 всем ссылкам ставит href="" (реальный URL — в
+  // data-href). Клик по <a href=""> без preventDefault = переход на пустой
+  // href = ПЕРЕЗАГРУЗКА страницы WebView 1С — редактор умирает целиком.
+  // closest("a") вместо instanceof: target может быть вложенным элементом
+  // (<span> codicon, <strong> внутри ссылки) — раньше такой клик терялся.
+  private static findAnchor(event: MouseEvent): HTMLAnchorElement {
+    const target: any = event.target;
+    return target && target.closest ? target.closest("a") : null;
+  }
+
   private onMarkdownClick(event: MouseEvent) {
-    if (event.target instanceof HTMLAnchorElement) {
-      const data = event.target.dataset.href;
-      EventsManager.fireEvent(this, VanessaEditorEvent.ON_MARK_CLICK, data);
+    const anchor = VanessaViwer.findAnchor(event);
+    if (anchor) {
+      event.preventDefault();
+      const data = anchor.dataset.href;
+      if (data) EventsManager.fireEvent(this, VanessaEditorEvent.ON_MARK_CLICK, data);
     }
   }
 
   private onWelcomeClick(event: MouseEvent) {
-    if (event.target instanceof HTMLAnchorElement) {
-      const id = event.target.dataset.event;
-      const data = event.target.dataset.href;
-      EventsManager.fireEvent(this, id, data);
+    const anchor = VanessaViwer.findAnchor(event);
+    if (anchor) {
+      event.preventDefault();
+      const id = anchor.dataset.event;
+      const data = anchor.dataset.href;
+      if (id) EventsManager.fireEvent(this, id, data);
     }
   }
 

--- a/test/viewer/viewer.test.ts
+++ b/test/viewer/viewer.test.ts
@@ -1,0 +1,63 @@
+import { VanessaTabs } from '../../src/vanessa-tabs';
+let expect = require('chai').expect;
+
+//@ts-ignore
+const tabs = window.VanessaTabs as VanessaTabs;
+
+// renderMarkdown 0.52.2 всем ссылкам ставит href="" (реальный URL — в data-href).
+// Клик без preventDefault = переход на пустой href = перезагрузка страницы
+// WebView 1С — редактор умирает целиком. Тесты фиксируют и контракт рендера,
+// и перехват клика (в т.ч. по вложенному в ссылку элементу).
+describe('Markdown-вьюер: клики по ссылкам', function () {
+  let eventsData: { name: string, data: any }[];
+  function bodyOnClickHandler(ev: Event) {
+    if (ev instanceof CustomEvent && !Number.isInteger(ev.detail)) {
+      eventsData.push(ev.detail);
+    }
+  }
+  const markdown = '# Урок\n\n[простая ссылка](Глава01/Урок02.md)\n\n[**жирная** ссылка](Глава02/Урок01.md)\n';
+
+  before((done) => {
+    document.body.addEventListener('click', bodyOnClickHandler);
+    eventsData = [];
+    tabs.view('', 'Тест вьюера', 'test-viewer.md', markdown);
+    setTimeout(done, 100);
+  });
+  after(() => {
+    document.body.removeEventListener('click', bodyOnClickHandler);
+    //@ts-ignore
+    tabs.current.domClose.click();
+  });
+
+  it('Рендер: href пуст, реальный URL — в data-href', () => {
+    const anchors = document.querySelectorAll('.vanessa-markdown a');
+    expect(anchors.length).to.be.at.least(2);
+    const a = anchors[0] as HTMLAnchorElement;
+    expect(a.getAttribute('href')).to.equal('');
+    expect(a.dataset.href).to.have.string('Урок02.md');
+  });
+
+  it('Клик по ссылке шлёт ON_MARK_CLICK и отменяет навигацию', () => {
+    eventsData = [];
+    const a = document.querySelector('.vanessa-markdown a') as HTMLAnchorElement;
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true, view: window });
+    a.dispatchEvent(ev);
+    expect(ev.defaultPrevented).to.equal(true); // иначе href="" перезагрузит WebView 1С
+    const message = eventsData.find(e => e.name === 'ON_MARK_CLICK');
+    expect(message).to.be.an('object');
+    expect(message.data).to.equal(a.dataset.href);
+  });
+
+  it('Клик по вложенному в ссылку элементу тоже работает', () => {
+    eventsData = [];
+    const strong = document.querySelector('.vanessa-markdown a strong') as HTMLElement;
+    expect(strong).to.not.equal(null);
+    const a = strong.closest('a') as HTMLAnchorElement;
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true, view: window });
+    strong.dispatchEvent(ev);
+    expect(ev.defaultPrevented).to.equal(true);
+    const message = eventsData.find(e => e.name === 'ON_MARK_CLICK');
+    expect(message).to.be.an('object');
+    expect(message.data).to.equal(a.dataset.href);
+  });
+});

--- a/tools/loaders/compile.js
+++ b/tools/loaders/compile.js
@@ -27,13 +27,17 @@ const WORKER_POLYFILL = [
   'if(typeof String.prototype.replaceAll!=="function"){Object.defineProperty(String.prototype,"replaceAll",{value:function(s,r){return s instanceof RegExp?String.prototype.replace.call(this,s,r):this.split(s).join(r)},writable:true,configurable:true});}',
   'if(typeof Array.prototype.at!=="function"){Object.defineProperty(Array.prototype,"at",{value:function(n){n=Math.trunc(n)||0;if(n<0)n+=this.length;return n<0||n>=this.length?undefined:this[n]},writable:true,configurable:true});}',
   'if(typeof String.prototype.at!=="function"){Object.defineProperty(String.prototype,"at",{value:function(n){n=Math.trunc(n)||0;if(n<0)n+=this.length;return n<0||n>=this.length?undefined:this.charAt(n)},writable:true,configurable:true});}',
-  'if(typeof String.prototype.matchAll!=="function"){Object.defineProperty(String.prototype,"matchAll",{value:function(re){var rx=re instanceof RegExp?new RegExp(re.source,re.flags.indexOf("g")>=0?re.flags:re.flags+"g"):new RegExp(re,"g");var str=String(this),out=[],m;while((m=rx.exec(str))!==null){out.push(m);if(m[0]==="")rx.lastIndex++}return out[Symbol.iterator]()},writable:true,configurable:true});}',
+  // глобальный RegExp не пересоздаём конструктором (он отвергает named groups, литерал-парсер — нет)
+  'if(typeof String.prototype.matchAll!=="function"){Object.defineProperty(String.prototype,"matchAll",{value:function(re){var rx,saved=0,own=false;if(re instanceof RegExp&&re.flags.indexOf("g")>=0){rx=re;own=true;saved=rx.lastIndex}else{rx=re instanceof RegExp?new RegExp(re.source,re.flags+"g"):new RegExp(re,"g")}var str=String(this),out=[],m;rx.lastIndex=0;while((m=rx.exec(str))!==null){out.push(m);if(m[0]==="")rx.lastIndex++}if(own)rx.lastIndex=saved;return out[Symbol.iterator]()},writable:true,configurable:true});}',
   // выровнено с polyfills.ts (#14): worker лишён своего глобального контекста, эти API monaco зовёт и в worker-коде (0.52.2: matchAll в textModelSync)
   'if(typeof String.prototype.trimStart!=="function"){Object.defineProperty(String.prototype,"trimStart",{value:function(){return String(this).replace(/^\\s+/,"")},writable:true,configurable:true});String.prototype.trimLeft=String.prototype.trimStart;}',
   'if(typeof String.prototype.trimEnd!=="function"){Object.defineProperty(String.prototype,"trimEnd",{value:function(){return String(this).replace(/\\s+$/,"")},writable:true,configurable:true});String.prototype.trimRight=String.prototype.trimEnd;}',
   'if(typeof Object.hasOwn!=="function"){Object.hasOwn=function(o,k){return Object.prototype.hasOwnProperty.call(o,k)};}',
   'if(typeof Array.prototype.findLast!=="function"){Object.defineProperty(Array.prototype,"findLast",{value:function(cb,t){for(var i=this.length-1;i>=0;i--){if(cb.call(t,this[i],i,this))return this[i]}return undefined},writable:true,configurable:true});}',
-  'if(typeof Array.prototype.findLastIndex!=="function"){Object.defineProperty(Array.prototype,"findLastIndex",{value:function(cb,t){for(var i=this.length-1;i>=0;i--){if(cb.call(t,this[i],i,this))return i}return -1},writable:true,configurable:true});}'
+  'if(typeof Array.prototype.findLastIndex!=="function"){Object.defineProperty(Array.prototype,"findLastIndex",{value:function(cb,t){for(var i=this.length-1;i>=0;i--){if(cb.call(t,this[i],i,this))return i}return -1},writable:true,configurable:true});}',
+  // выровнено с polyfills.ts: Promise.finally (Safari 11.1) и Symbol.asyncIterator (Safari 12) — общие модули monaco (async.js) попадают и в worker-бандл
+  'if(typeof Promise.prototype.finally!=="function"){Promise.prototype.finally=function(cb){return this.then(function(v){return Promise.resolve(cb()).then(function(){return v})},function(e){return Promise.resolve(cb()).then(function(){throw e})})};}',
+  'if(!Symbol.asyncIterator){Object.defineProperty(Symbol,"asyncIterator",{value:Symbol.for("Symbol.asyncIterator"),configurable:true});}'
 ].join('')
 
 module.exports.pitch = function pitch (remainingRequest) {


### PR DESCRIPTION
После перехода на monaco 0.52.2 (#185) во встроенном WebKit 1С (≈Safari 11)
не работал весь drag-интерактив и ломался редактор при клике по ссылке урока.

## Причины

1. monaco 0.52.2 строит drag-интерактив на Pointer Events (Safari 13+),
   которых в WebKit 1С нет: скроллбары, минимап и стрелки стартуют прямо
   с `pointerdown` (мертвы целиком), выделение стартует с mousedown, но
   тянется через `GlobalPointerMoveMonitor` (pointermove/pointerup) — drag
   мёртв. Клики работали, поэтому автотесты проблему не видели.
2. `renderMarkdown` 0.52.2 ставит всем ссылкам `href=""` (реальный URL — в
   `data-href`). Обработчик кликов вьюера не отменял действие по умолчанию —
   клик по ссылке урока означал переход на пустой href, то есть перезагрузку
   страницы WebView: редактор умирал целиком.
3. `Symbol.asyncIterator` (Safari 12) отсутствует — `for await` в hover
   (HoverOperation) падал с TypeError, monaco гасил ошибку → подсказки при
   наведении молча не показывались.

## Что сделано

- Полифил Pointer Events: трансляция mouse→pointer на capture-фазе document
  (`mousedown→pointerdown`, `mousemove→pointermove`, `mouseup→pointerup`).
  `setPointerCapture` не эмулируется — monaco при его отсутствии сам
  переключается на window-слушатели; `window.PointerEvent` не определяется,
  чтобы выбор обработчиков monaco не менялся. `preventDefault()` на
  pointerdown зеркалится в mousedown по спецификации.
- `MouseEvent.buttons` (Safari 11.1) — битовая маска на прототипе: монитор
  drag сверяет `buttons` каждого pointermove с начальным значением.
- `Symbol.asyncIterator`, `Promise.prototype.finally` (резолв элемента
  списка автодополнения), `Element.prototype.toggleAttribute` (quick input);
  страховки: `AggregateError`, стабы User Timing, `Blob.prototype.arrayBuffer`.
- matchAll-полифил: глобальный RegExp итерируется без пересоздания
  конструктором (конструктор WebKit 1С отвергает named groups, которые
  литерал-парсер принимает).
- Вьюер: `preventDefault()` + `closest('a')` — перехват кликов по ссылкам,
  включая клики по вложенным элементам (иконки, выделение в тексте ссылки).
- `stickyScroll` и `dropIntoEditor` выключены (в 0.52.2 включены по
  умолчанию: первый — новый виджет поверх кода, второй читает
  `dataTransfer.items`/`Blob.arrayBuffer` без guard'ов).
