### PR TITLE
fix: пустой редактор после закрытия вкладки сравнения (monaco 0.52.2)

### DIFF
--- a/src/media/tabs.css
+++ b/src/media/tabs.css
@@ -186,9 +186,12 @@ a[data-href] {
     text-overflow: ellipsis
 }
 
-#VanessaEditorContainer>div.monaco-diff-editor {
-    position: absolute !important;
-    height: 100%;
+div.vanessa-diff-editor {
+    position: relative !important;
+}
+
+div.vanessa-diff-editor>div.monaco-diff-editor {
+    width: 100%;
 }
 
 div.vanessa-editor {

--- a/src/vanessa-diff-editor.ts
+++ b/src/vanessa-diff-editor.ts
@@ -1,10 +1,13 @@
 import * as monaco from "monaco-editor";
+import * as dom from 'monaco-editor/esm/vs/base/browser/dom';
 import "./languages/bsl/contribution";
 import "./languages/turbo-gherkin/contribution";
 import { language as gherkin } from './languages/turbo-gherkin/configuration'
 import { IVanessaEditor, EventsManager, createModel, VanessaEditorEvent, disposeModel, VAEditorType } from "./common";
 import { VanessaEditor } from "./vanessa-editor";
 import { VanessaTabs } from "./vanessa-tabs";
+
+const $ = dom.$;
 
 export class VanessaDiffEditor implements IVanessaEditor {
 
@@ -14,6 +17,7 @@ export class VanessaDiffEditor implements IVanessaEditor {
   // теперь через методы самого редактора (goToDiff/getLineChanges) — см. ниже.
   public editor: monaco.editor.IStandaloneDiffEditor;
   public eventsManager: EventsManager;
+  private _domNode: HTMLElement;
 
   public static createStandalone(
     original: string = "",
@@ -40,8 +44,16 @@ export class VanessaDiffEditor implements IVanessaEditor {
   }
 
   constructor(model: monaco.editor.IDiffEditorModel, readOnly: boolean = false) {
-    let node = document.getElementById("VanessaEditorContainer");
-    this.editor = monaco.editor.createDiffEditor(node, {
+    // 0.52.2: новый DiffEditorWidget монтирует свой корень прямо в переданный
+    // элемент, а getContainerDomNode() возвращает сам переданный элемент —
+    // не собственный div, как в 0.30. Если создавать виджет в общем
+    // #VanessaEditorContainer, то domNode() == общий контейнер, и
+    // hideEditor при закрытии diff-вкладки прячет ВСЕ редакторы (белое поле).
+    // Поэтому diff живёт в собственной обёртке — как VanessaEditor/VanessaViwer.
+    const container = document.getElementById("VanessaEditorContainer");
+    this._domNode = $("div", { class: "vanessa-diff-editor" });
+    container.appendChild(this._domNode);
+    this.editor = monaco.editor.createDiffEditor(this._domNode, {
       contextmenu: false,
       originalEditable: false,
       scrollBeyondLastLine: false,
@@ -79,6 +91,8 @@ export class VanessaDiffEditor implements IVanessaEditor {
     this.editor.dispose();
     disposeModel(original);
     disposeModel(modified);
+    if (this._domNode) this._domNode.remove();
+    this._domNode = null;
   }
 
   public resetModel() {
@@ -117,9 +131,7 @@ export class VanessaDiffEditor implements IVanessaEditor {
     });
   }
 
-  // 0.52.2: приватного _containerDomElement больше нет (новый DiffEditorWidget
-  // хранит контейнер в _domElement) — используем публичный getContainerDomNode().
-  public domNode = () => this.editor.getContainerDomNode();
+  public domNode = () => this._domNode;
   public onFileSave = () => this.fireEvent(VanessaEditorEvent.PRESS_CTRL_S, this.getModel());
   public fireEvent = (event: any, arg: any = undefined) => this.eventsManager.fireEvent(event, arg);
   public setReadOnly = (arg: boolean) => this.editor.updateOptions({ readOnly: arg });

--- a/test/editor/editor.test.ts
+++ b/test/editor/editor.test.ts
@@ -15,6 +15,10 @@ const url = 'Браузер.feature';
 const title = 'Заголовок файла';
 
 describe('Управление редактором', function () {
+  // Первый сьют прогона: холодная инициализация monaco в WebKit 1С на медленных
+  // машинах не укладывается в дефолтные 2000 мс mocha — before-хук падает по
+  // таймауту и все 12 тестов сьюта скипаются.
+  this.timeout(15000);
   let eventsData: {name:string, data:any, editor:IVanessaEditor}[];
   let editor: VanessaEditor;
 

--- a/test/tabs/tabs.test.ts
+++ b/test/tabs/tabs.test.ts
@@ -1,0 +1,51 @@
+import { VanessaTabs } from '../../src/vanessa-tabs';
+let expect = require('chai').expect;
+
+//@ts-ignore
+const tabs = window.VanessaTabs as VanessaTabs;
+
+// 0.52.2: DiffEditorWidget монтирует свой корень прямо в переданный элемент,
+// а getContainerDomNode() возвращает сам переданный элемент (в 0.30 виджет
+// создавал собственный div и отдавал его). Если domNode() diff-редактора —
+// общий #VanessaEditorContainer, закрытие diff-вкладки вешает на него
+// vanessa-hidden и прячет все редакторы: вместо редактора остаётся пустое
+// поле. Тесты фиксируют контракт: у diff-редактора собственный узел, после
+// закрытия diff-вкладки предыдущий редактор снова видим.
+describe('Diff-вкладка: закрытие возвращает предыдущий редактор', function () {
+  this.timeout(15000); // создание diff-редактора + таймеры showEditor: WebKit 1С медленный
+  const container = () => document.getElementById('VanessaEditorContainer');
+
+  before((done) => {
+    tabs.edit('Функционал: тест вкладок', 'tabs-close.feature', 'tabs-close.feature', 'Тест вкладок', 0, false, true);
+    tabs.diff('старый текст', 'diff-old.json', 'diff-old.json', 'новый текст', 'diff-new.json', 'diff-new.json', 'Сравнение', 0, true, true);
+    setTimeout(done, 400); // дать отработать таймерам showEditor (100/300 мс)
+  });
+
+  after(() => {
+    //@ts-ignore
+    tabs.findTab(t => t.title === 'Сравнение')?.close();
+    //@ts-ignore
+    tabs.findTab(t => t.title === 'Тест вкладок')?.close();
+  });
+
+  it('domNode() diff-редактора — собственный узел внутри контейнера', () => {
+    expect(tabs.isDiffEditor).to.equal(true);
+    const node = tabs.diffEditor.domNode();
+    expect(node).to.not.equal(container());
+    expect(node.parentElement).to.equal(container());
+  });
+
+  it('закрытие diff-вкладки не прячет общий контейнер', (done) => {
+    //@ts-ignore
+    tabs.current.close();
+    expect(container().classList.contains('vanessa-hidden')).to.equal(false);
+    setTimeout(() => {
+      expect(tabs.isCodeEditor).to.equal(true);
+      const node = tabs.editor.domNode();
+      expect(node.parentElement).to.equal(container());
+      expect(getComputedStyle(node).display).to.not.equal('none');
+      expect(getComputedStyle(container()).display).to.not.equal('none');
+      done();
+    }, 400);
+  });
+});


### PR DESCRIPTION
## Проблема

VanessaTabs держит DOM-узлы всех редакторов в общем `#VanessaEditorContainer` (CSS показывает последний дочерний div), и каждый редактор через `domNode()` отдаёт свой личный узел — по нему вкладки переключаются и прячутся.

DiffEditorWidget monaco 0.52.2 монтирует свой корень (`elements.root`, `.monaco-diff-editor`) прямо в переданный элемент, а `getContainerDomNode()` возвращает **сам переданный элемент** — не собственный div, как в 0.30. `VanessaDiffEditor` создавался в общем контейнере, поэтому `domNode()` отдавал
общий контейнер всех редакторов (регрессия #185; на 0.55 после #182`_containerDomElement` был undefined — та же ошибка в другой форме).

Проявления:

- закрыть diff-вкладку (например, «Сравнить текущие настройки с файлом» в VA) → `hideEditor` вешает `vanessa-hidden` (`display:none !important`) на весь контейнер → вместо редактора пустое поле, на всех вкладках, переключением не лечится;
- до закрытия: уйти с diff-вкладки на другую и вернуться → diff-вкладка показывает контент чужой вкладки (re-append «своего» узла = re-append всего контейнера, порядок детей внутри не меняется).

## Решение

Diff-редактор создаётся в собственной обёртке `div.vanessa-diff-editor` внутри контейнера — тот же паттерн, что у `VanessaEditor` и `VanessaViwer`; `domNode()` возвращает обёртку, `dispose()` её удаляет. CSS-правило для `.monaco-diff-editor` как прямого потомка контейнера заменено правилами обёртки.

Отдельным коммитом: `this.timeout(15000)` первому сьюту автотеста («Управление редактором») — холодная инициализация monaco в WebKit 1С на медленных машинах не укладывается в дефолтные 2000 мс mocha, before-хук падал по таймауту и 12 тестов сьюта молча скипались.

Побочно фикс убирает коллизию scoped context-key сервиса monaco при двух diff-редакторах на одном элементе (`createScoped` на общем контейнере писал `console.error` и затирал contextId первого).
